### PR TITLE
Fix feed loading and add sentiment badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,27 @@ CHANGELOG:
     background: var(--bg);
   }
 
+  .badge.sentiment {
+    background: var(--bg);
+    border-color: var(--border);
+    color: var(--muted);
+  }
+
+  .badge.sentiment.positive {
+    border-color: var(--ok);
+    color: var(--ok);
+  }
+
+  .badge.sentiment.negative {
+    border-color: var(--err);
+    color: var(--err);
+  }
+
+  .badge.sentiment.neutral {
+    border-color: var(--muted);
+    color: var(--muted);
+  }
+
   .breaking-indicator {
     display: inline-block;
     background: var(--err);
@@ -358,6 +379,17 @@ CHANGELOG:
     display: flex;
     gap: 0.5rem;
     margin-top: 1rem;
+  }
+
+  .source-header {
+    margin: 2rem 0 1rem;
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent);
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
   }
   
   .article-link {
@@ -735,42 +767,88 @@ CHANGELOG:
 /* ================= PRODUCTION EDITION ================= */
 
 const SOURCES = [
-  { id:'breitbart', name:'Breitbart', url:'https://www.breitbart.com/feed/', lane:'populist' },
-  { id:'federalist', name:'The Federalist', url:'https://thefederalist.com/feed/', lane:'conservative' },
-  { id:'dailywire', name:'Daily Wire', url:'https://www.dailywire.com/feeds/rss.xml', lane:'conservative' },
-  { id:'gateway', name:'Gateway Pundit', url:'https://www.thegatewaypundit.com/feed/', lane:'populist' },
-  { id:'infowars', name:'InfoWars', url:'https://www.infowars.com/rss.xml', lane:'populist' },
-  { id:'revolver', name:'Revolver News', url:'https://www.revolver.news/feed/', lane:'populist' },
-  { id:'natfile', name:'National File', url:'https://nationalfile.com/feed/', lane:'populist' },
-  { id:'tplvoice', name:"People's Voice", url:'https://thepeoplesvoice.tv/feed/', lane:'populist' },
-  { id:'libertydaily', name:'Liberty Daily', url:'https://thelibertydaily.com/rss.xml', lane:'populist' },
-  { id:'naturalnews', name:'Natural News', url:'https://www.naturalnews.com/rss.xml', lane:'populist' },
-  { id:'dailycaller', name:'Daily Caller', url:'https://dailycaller.com/feed/', lane:'conservative' },
-  { id:'redstate', name:'RedState', url:'https://redstate.com/feed/', lane:'conservative' },
-  { id:'amgreat', name:'AmGreatness', url:'https://amgreatness.com/feed/', lane:'conservative' },
-  { id:'pjm', name:'PJ Media', url:'https://pjmedia.com/feeds/latest', lane:'conservative' },
-  { id:'nypost', name:'NY Post', url:'https://nypost.com/feed/', lane:'populist' },
-  { id:'townhall', name:'Townhall', url:'https://townhall.com/rss', lane:'conservative' },
-  { id:'foxnews', name:'Fox News', url:'https://feeds.foxnews.com/foxnews/latest', lane:'conservative' },
-  { id:'washexam', name:'Washington Examiner', url:'https://www.washingtonexaminer.com/feed', lane:'conservative' },
-  { id:'theblaze', name:'The Blaze', url:'https://www.theblaze.com/feeds/latest.rss', lane:'conservative' }
+  { id: 'breitbart', name: 'Breitbart', url: 'https://www.breitbart.com/feed/', lane: 'populist' },
+  { id: 'federalist', name: 'The Federalist', url: 'https://thefederalist.com/feed/', lane: 'conservative' },
+  { id: 'dailywire', name: 'Daily Wire', url: 'https://www.dailywire.com/feeds/rss.xml', lane: 'conservative' },
+  { id: 'gateway', name: 'Gateway Pundit', url: 'https://www.thegatewaypundit.com/feed/', lane: 'populist' },
+  { id: 'infowars', name: 'InfoWars', url: 'https://www.infowars.com/rss.xml', lane: 'populist' },
+  { id: 'revolver', name: 'Revolver News', url: 'https://www.revolver.news/feed/', lane: 'populist' },
+  { id: 'natfile', name: 'National File', url: 'https://nationalfile.com/feed/', lane: 'populist' },
+  { id: 'tplvoice', name: "People's Voice", url: 'https://thepeoplesvoice.tv/feed/', lane: 'populist' },
+  { id: 'libertydaily', name: 'Liberty Daily', url: 'https://thelibertydaily.com/rss.xml', lane: 'populist' },
+  { id: 'naturalnews', name: 'Natural News', url: 'https://www.naturalnews.com/rss.xml', lane: 'populist' },
+  { id: 'dailycaller', name: 'Daily Caller', url: 'https://dailycaller.com/feed/', lane: 'conservative' },
+  { id: 'redstate', name: 'RedState', url: 'https://redstate.com/feed/', lane: 'conservative' },
+  { id: 'amgreat', name: 'AmGreatness', url: 'https://amgreatness.com/feed/', lane: 'conservative' },
+  { id: 'pjm', name: 'PJ Media', url: 'https://pjmedia.com/feeds/latest', lane: 'conservative' },
+  { id: 'nypost', name: 'NY Post', url: 'https://nypost.com/feed/', lane: 'populist' },
+  { id: 'townhall', name: 'Townhall', url: 'https://townhall.com/rss', lane: 'conservative' },
+  { id: 'foxnews', name: 'Fox News', url: 'https://feeds.foxnews.com/foxnews/latest', lane: 'conservative' },
+  { id: 'washexam', name: 'Washington Examiner', url: 'https://www.washingtonexaminer.com/feed', lane: 'conservative' },
+  { id: 'theblaze', name: 'The Blaze', url: 'https://www.theblaze.com/feeds/latest.rss', lane: 'conservative' }
 ];
 
+const persistedState = loadPersistedState();
+
 const STATE = {
-  enabled: new Set(loadEnabled() || SOURCES.map(s=>s.id)),
+  enabled: new Set(persistedState.enabled || SOURCES.map(source => source.id)),
   items: [],
   view: 'all',
   loading: false,
   lastFetch: 0,
   cache: new Map(),
-  expandedCards: new Set(),
+  expandedCards: new Set(persistedState.expanded || []),
   trendingKeywords: new Map()
 };
 
 const CACHE_TTL = 120000;
+const FETCH_TIMEOUT = 4000;
 
-// Performance: batch DOM operations
+const POSITIVE_WORDS = new Set([
+  'win', 'wins', 'won', 'victory', 'success', 'secure', 'secured', 'boost', 'rise', 'surge',
+  'growth', 'growing', 'strong', 'support', 'praise', 'gain', 'gains', 'positive', 'good', 'safe',
+  'peace', 'upbeat', 'improve', 'improves', 'improved', 'progress', 'benefit', 'benefits'
+]);
+
+const NEGATIVE_WORDS = new Set([
+  'loss', 'losses', 'lost', 'defeat', 'crisis', 'risk', 'risks', 'fear', 'fears', 'concern',
+  'concerns', 'drop', 'drops', 'decline', 'declines', 'fall', 'falls', 'negative', 'bad', 'threat',
+  'threats', 'fraud', 'attack', 'attacks', 'scandal', 'crash', 'collapse', 'danger', 'lawsuit',
+  'lawsuits', 'probe', 'probes', 'charge', 'charges', 'investigation', 'chaos'
+]);
+
+const ESCAPE_MAP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+};
+
 let domUpdates = [];
+
+function loadPersistedState() {
+  try {
+    const enabled = JSON.parse(localStorage.getItem('urnews.enabled'));
+    const expanded = JSON.parse(localStorage.getItem('urnews.expanded'));
+    return {
+      enabled: Array.isArray(enabled) && enabled.length ? enabled : null,
+      expanded: Array.isArray(expanded) ? expanded : null
+    };
+  } catch (error) {
+    return { enabled: null, expanded: null };
+  }
+}
+
+function persistState() {
+  try {
+    localStorage.setItem('urnews.enabled', JSON.stringify([...STATE.enabled]));
+    localStorage.setItem('urnews.expanded', JSON.stringify([...STATE.expandedCards]));
+  } catch (error) {
+    console.warn('Storage failed:', error);
+  }
+}
+
 function batchDOM(fn) {
   domUpdates.push(fn);
   if (domUpdates.length === 1) {
@@ -793,87 +871,153 @@ function setCached(url, data) {
   STATE.cache.set(url, { data, timestamp: Date.now() });
 }
 
-// Optimized fetch with better error handling
+function fetchProxy(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+  const promise = fetch(url, { signal: controller.signal }).then(response => {
+    clearTimeout(timer);
+    if (!response.ok) {
+      throw new Error('Bad response');
+    }
+    return response;
+  }).catch(error => {
+    clearTimeout(timer);
+    throw error;
+  });
+
+  return {
+    promise,
+    cancel() {
+      clearTimeout(timer);
+      controller.abort();
+    }
+  };
+}
+
+function firstSuccessful(promises) {
+  return new Promise((resolve, reject) => {
+    let remaining = promises.length;
+    const errors = [];
+
+    promises.forEach((promise, index) => {
+      promise
+        .then(value => resolve({ value, index }))
+        .catch(error => {
+          errors.push(error);
+          remaining -= 1;
+          if (remaining === 0) {
+            reject(errors[errors.length - 1] || new Error('All proxies failed'));
+          }
+        });
+    });
+  });
+}
+
 async function fetchFast(url) {
   const cached = getCached(url);
-  if (cached) return Promise.resolve(cached);
+  if (cached) {
+    return cached;
+  }
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 4000);
+  const targets = [
+    `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+    `https://corsproxy.io/?${encodeURIComponent(url)}`
+  ].map(fetchProxy);
 
   try {
-    const response = await Promise.race([
-      fetch('https://api.allorigins.win/raw?url=' + encodeURIComponent(url), {
-        signal: controller.signal
-      }),
-      fetch('https://corsproxy.io/?' + encodeURIComponent(url), {
-        signal: controller.signal
-      })
-    ]);
-
-    clearTimeout(timeout);
-    if (!response.ok) throw new Error('Failed');
-    
+    const { value: response, index } = await firstSuccessful(targets.map(target => target.promise));
     const text = await response.text();
-    if (text && text.length > 100) {
-      setCached(url, text);
-      return text;
+    targets.forEach((target, idx) => {
+      if (idx !== index) {
+        target.cancel();
+      }
+    });
+    if (!text || text.length < 100) {
+      throw new Error('Empty feed');
     }
-    throw new Error('Empty');
-  } catch(e) {
-    clearTimeout(timeout);
-    throw e;
+    setCached(url, text);
+    return text;
+  } finally {
+    targets.forEach(target => target.cancel());
   }
 }
 
 function calculateTrending(items) {
   const keywords = new Map();
   const now = Date.now();
-  
+
   items.forEach(item => {
-    const age = (now - new Date(item.pubDate)) / (1000 * 60 * 60);
-    if (age > 24) return;
-    
-    const text = (item.title + ' ' + item.desc).toLowerCase();
+    const ageHours = (now - new Date(item.pubDate)) / (1000 * 60 * 60);
+    if (ageHours > 24) {
+      return;
+    }
+
+    const text = `${item.title} ${item.desc}`.toLowerCase();
     const words = text.match(/\b[a-z]{4,}\b/g) || [];
-    
+
     words.forEach(word => {
       if (!/^(with|that|this|from|have|were|been|their|about|would|could|should)$/.test(word)) {
         const current = keywords.get(word) || 0;
-        keywords.set(word, current + (1 / Math.max(1, age / 6)));
+        keywords.set(word, current + (1 / Math.max(1, ageHours / 6)));
       }
     });
   });
-  
+
   STATE.trendingKeywords = keywords;
-  
+
   items.forEach(item => {
-    const text = (item.title + ' ' + item.desc).toLowerCase();
+    const text = `${item.title} ${item.desc}`.toLowerCase();
     let score = 0;
-    
     keywords.forEach((weight, word) => {
       if (text.includes(word)) {
         score += weight;
       }
     });
-    
     item.trendingScore = score;
   });
 }
 
+function analyzeSentiment(item) {
+  const text = `${item.title} ${item.desc}`.toLowerCase();
+  const tokens = text.match(/\b[a-z]+\b/g) || [];
+  let score = 0;
+
+  tokens.forEach(word => {
+    if (POSITIVE_WORDS.has(word)) {
+      score += 1;
+    } else if (NEGATIVE_WORDS.has(word)) {
+      score -= 1;
+    }
+  });
+
+  const label = score > 0 ? 'POSITIVE' : score < 0 ? 'NEGATIVE' : 'NEUTRAL';
+  return { label, tone: label.toLowerCase(), score };
+}
+
+function createCardId(link) {
+  let hash = 0;
+  for (let i = 0; i < link.length; i += 1) {
+    hash = (hash << 5) - hash + link.charCodeAt(i);
+    hash |= 0;
+  }
+  return `card-${Math.abs(hash)}`;
+}
+
 function parseRSS(xmlString, source) {
   const doc = new DOMParser().parseFromString(xmlString, 'text/xml');
-  if (doc.getElementsByTagName('parsererror')[0]) return [];
+  if (doc.getElementsByTagName('parsererror')[0]) {
+    return [];
+  }
 
   return Array.from(doc.querySelectorAll('item, entry'))
     .slice(0, 15)
-    .map(item => {
-      const title = (item.querySelector('title')?.textContent || '').trim();
-      const link = (item.querySelector('link')?.getAttribute('href') || 
-                   item.querySelector('link')?.textContent || '').trim();
-      const pubDate = (item.querySelector('pubDate, updated, published')?.textContent || '').trim();
-      const desc = (item.querySelector('description, summary')?.textContent || '').trim();
-      
+    .map(entry => {
+      const title = (entry.querySelector('title')?.textContent || '').trim();
+      const link = (entry.querySelector('link')?.getAttribute('href') || entry.querySelector('link')?.textContent || '').trim();
+      const pubDate = (entry.querySelector('pubDate, updated, published')?.textContent || '').trim();
+      const desc = (entry.querySelector('description, summary')?.textContent || '').trim();
+
       return {
         title,
         link,
@@ -886,7 +1030,7 @@ function parseRSS(xmlString, source) {
         trendingScore: 0
       };
     })
-    .filter(x => x.title && x.link && x.title.length > 15);
+    .filter(item => item.title && item.link && item.title.length > 15);
 }
 
 function stripHTML(html) {
@@ -895,366 +1039,471 @@ function stripHTML(html) {
   return temp.textContent.replace(/\s+/g, ' ').trim();
 }
 
-function saveEnabled() {
-  try {
-    localStorage.setItem('urnews.enabled', JSON.stringify([...STATE.enabled]));
-    localStorage.setItem('urnews.expanded', JSON.stringify([...STATE.expandedCards]));
-  } catch(e) {
-    console.warn('Storage failed:', e);
-  }
-}
-
-function loadEnabled() {
-  try { 
-    const expanded = JSON.parse(localStorage.getItem('urnews.expanded'));
-    if (expanded) STATE.expandedCards = new Set(expanded);
-    return JSON.parse(localStorage.getItem('urnews.enabled'));
-  } catch(e) { 
-    return null;
-  }
-}
-
-// Show loading skeletons
 function showLoading() {
   const feedList = document.getElementById('feedList');
   feedList.innerHTML = '';
-  
-  for(let i = 0; i < 8; i++) {
+  const fragment = document.createDocumentFragment();
+
+  for (let i = 0; i < 8; i += 1) {
     const skeleton = document.createElement('div');
     skeleton.className = 'loading-card';
     skeleton.innerHTML = `
       <div class="skeleton loading-title"></div>
       <div class="skeleton loading-meta"></div>
     `;
-    feedList.appendChild(skeleton);
+    fragment.appendChild(skeleton);
+  }
+
+  feedList.appendChild(fragment);
+}
+
+async function loadFeeds() {
+  if (STATE.loading) {
+    return;
+  }
+
+  const enabledSources = SOURCES.filter(source => STATE.enabled.has(source.id));
+  if (enabledSources.length === 0) {
+    STATE.items = [];
+    render();
+    document.getElementById('lastUpdated').textContent = '• NO SOURCES';
+    return;
+  }
+
+  STATE.loading = true;
+  STATE.lastFetch = Date.now();
+  showLoading();
+
+  try {
+    const fetches = enabledSources.map(source =>
+      fetchFast(source.url)
+        .then(text => parseRSS(text, source))
+        .catch(error => {
+          console.warn('Feed failed:', source.name, error);
+          return [];
+        })
+    );
+
+    const results = await Promise.all(fetches);
+    const allItems = results.flat();
+
+    const deduped = [];
+    const seen = new Set();
+
+    allItems
+      .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate))
+      .forEach(item => {
+        if (!seen.has(item.link)) {
+          seen.add(item.link);
+          deduped.push(item);
+        }
+      });
+
+    STATE.items = deduped.slice(0, 100);
+    calculateTrending(STATE.items);
+    STATE.items.forEach(item => {
+      const sentiment = analyzeSentiment(item);
+      item.sentimentScore = sentiment.score;
+      item.sentimentLabel = sentiment.label;
+      item.sentimentTone = sentiment.tone;
+    });
+
+    render();
+    document.getElementById('lastUpdated').textContent = `• ${new Date().toLocaleTimeString()}`;
+    toast(`${STATE.items.length} articles loaded`, 'success');
+  } catch (error) {
+    console.error('Failed:', error);
+    document.getElementById('lastUpdated').textContent = '• RETRY';
+    toast('Loading failed', 'error');
+  } finally {
+    STATE.loading = false;
   }
 }
 
-// Optimized parallel loader
-async function loadFeeds()
-
-
-  {
-if (STATE.loading) return;
-STATE.loading = true;
-STATE.lastFetch = Date.now();
-showLoading();
-try {
-const enabledSources = SOURCES.filter(s => STATE.enabled.has(s.id));
-const promises = enabledSources.map(source => 
-  fetchFast(source.url)
-    .then(text => parseRSS(text, source))
-    .catch(() => [])
-);
-
-const results = await Promise.allSettled(promises);
-const allItems = results
-  .filter(r => r.status === 'fulfilled')
-  .flatMap(r => r.value)
-  .sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
-
-STATE.items = allItems.slice(0, 100);
-
-calculateTrending(STATE.items);
-
-render();
-
-document.getElementById('lastUpdated').textContent = 
-  `• ${new Date().toLocaleTimeString()}`;
-
-toast(`${STATE.items.length} articles loaded`, 'success');
-} catch (error) {
-console.error('Failed:', error);
-toast('Loading failed', 'error');
-} finally {
-STATE.loading = false;
-}
-}
-// Enhanced article reader
 async function openReader(item) {
-const modal = document.getElementById('readerModal');
-const title = document.getElementById('readerTitle');
-const content = document.getElementById('readerContent');
-modal.classList.add('active');
-title.textContent = item.title;
-content.innerHTML = '<div class="reader-loading">LOADING ARTICLE...</div>';
-// Focus management
-document.getElementById('readerClose').focus();
-const blockedDomains = ['nypost.com', 'wsj.com', 'ft.com'];
-const domain = new URL(item.link).hostname;
-if (blockedDomains.some(blocked => domain.includes(blocked))) {
-content.innerHTML =       <div class="reader-error">         This source blocks external readers.          Please visit the article directly.       </div>    ;
-return;
+  const modal = document.getElementById('readerModal');
+  const title = document.getElementById('readerTitle');
+  const content = document.getElementById('readerContent');
+  modal.classList.add('active');
+  title.textContent = item.title;
+  content.innerHTML = '<div class="reader-loading">LOADING ARTICLE...</div>';
+  document.getElementById('readerClose').focus();
+
+  let hostname = '';
+  try {
+    hostname = new URL(item.link).hostname;
+  } catch (error) {
+    hostname = '';
+  }
+
+  const blockedDomains = ['nypost.com', 'wsj.com', 'ft.com'];
+  if (blockedDomains.some(domain => hostname.includes(domain))) {
+    content.innerHTML = `
+      <div class="reader-error">
+        This source blocks external readers. Please visit the article directly.
+      </div>
+    `;
+    return;
+  }
+
+  try {
+    const proxyUrl = `https://12ft.io/${item.link}`;
+    const response = await fetch('https://api.allorigins.win/raw?url=' + encodeURIComponent(proxyUrl));
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+
+    doc.querySelectorAll('script, style, nav, header, footer, aside').forEach(el => el.remove());
+
+    const article = doc.querySelector('article, main, [role="main"], .content, .article-body') || doc.body;
+    const paragraphs = Array.from(article.querySelectorAll('p'))
+      .map(p => p.textContent.trim())
+      .filter(text => text.length > 50)
+      .slice(0, 30)
+      .map(text => `<p>${escapeHTML(text)}</p>`)
+      .join('');
+
+    content.innerHTML = `
+      <div class="reader-content">
+        ${paragraphs || 'Unable to extract article content.'}
+      </div>
+    `;
+  } catch (error) {
+    content.innerHTML = `
+      <div class="reader-content">
+        <p><strong>Summary:</strong></p>
+        <p>${escapeHTML(item.desc || 'No summary available.')}</p>
+        <p style="margin-top: 2rem;">
+          <a href="${escapeHTML(item.link)}" target="_blank" rel="noopener" style="color: var(--accent);">
+            Click here to read the full article →
+          </a>
+        </p>
+      </div>
+    `;
+  }
 }
-try {
-const proxyUrl = 'https://12ft.io/' + item.link;
-const response = await fetch('https://api.allorigins.win/raw?url=' + encodeURIComponent(proxyUrl));
-const html = await response.text();
-const parser = new DOMParser();
-const doc = parser.parseFromString(html, 'text/html');
 
-doc.querySelectorAll('script, style, nav, header, footer, aside').forEach(el => el.remove());
-
-const article = doc.querySelector('article, main, [role="main"], .content, .article-body') || doc.body;
-
-const paragraphs = Array.from(article.querySelectorAll('p'))
-  .map(p => p.textContent.trim())
-  .filter(text => text.length > 50)
-  .slice(0, 30)
-  .map(text => `<p>${escapeHTML(text)}</p>`)
-  .join('');
-
-content.innerHTML = `<div class="reader-content">${paragraphs || 'Unable to extract article content.'}</div>`;
-} catch (e) {
-content.innerHTML =       <div class="reader-content">         <p><strong>Summary:</strong></p>         <p>${escapeHTML(item.desc || 'No summary available.')}</p>         <p style="margin-top: 2rem;">           <a href="${escapeHTML(item.link)}" target="_blank" style="color: var(--accent);">             Click here to read the full article →           </a>         </p>       </div>    ;
-}
-}
 function createCard(item) {
-const cardId = btoa(item.link).slice(0, 16);
-const isExpanded = STATE.expandedCards.has(cardId);
-const isTrending = item.trendingScore > 5;
-const article = document.createElement('article');
-article.className = card smooth ${isExpanded ? 'open' : ''} ${isTrending ? 'popular' : ''};
-article.dataset.cardId = cardId;
-const hostname = new URL(item.link).hostname;
-const timeString = fmtTime(item.pubDate);
-article.innerHTML =     <div class="card-head" tabindex="0" role="button" aria-expanded="${isExpanded}" aria-controls="body-${cardId}">       <span class="favicon" style="background-image:url('https://www.google.com/s2/favicons?domain=${hostname}&sz=64');" aria-hidden="true"></span>       <div>         <div class="titleline">           ${escapeHTML(item.title)}           ${item.isBreaking ? '<span class="breaking-indicator">BREAKING</span>' : ''}         </div>         <div class="tag">           ${escapeHTML(item.source)} • <span class="time">${timeString}</span>           ${isTrending ? '<span class="badge trending">TRENDING</span>' : ''}         </div>       </div>       <div class="expand-btn" aria-hidden="true">${isExpanded ? '▼' : '▶'}</div>     </div>     <div class="card-body" id="body-${cardId}" role="region">       <div>${escapeHTML(item.desc || 'No summary available.')}</div>       <div class="card-actions">         <a href="${escapeHTML(item.link)}" target="_blank" class="article-link smooth">           OPEN SOURCE         </a>         <button class="article-link read-btn smooth">           READ HERE         </button>       </div>     </div>  ;
-const header = article.querySelector('.card-head');
-const expandBtn = article.querySelector('.expand-btn');
-const readBtn = article.querySelector('.read-btn');
-const toggleCard = () => {
-const isOpen = article.classList.toggle('open');
-expandBtn.textContent = isOpen ? '▼' : '▶';
-header.setAttribute('aria-expanded', isOpen);
-if (isOpen) {
-  STATE.expandedCards.add(cardId);
-  // Close others for better UX
-  document.querySelectorAll('.card.open').forEach(card => {
-    if (card !== article) {
-      card.classList.remove('open');
-      const btn = card.querySelector('.expand-btn');
-      const hdr = card.querySelector('.card-head');
-      btn.textContent = '▶';
-      hdr.setAttribute('aria-expanded', 'false');
-      STATE.expandedCards.delete(card.dataset.cardId);
-    }
-  });
-} else {
-  STATE.expandedCards.delete(cardId);
-}
-saveEnabled();
-};
-header.addEventListener('click', toggleCard);
-header.addEventListener('keydown', (e) => {
-if (e.key === 'Enter' || e.key === ' ') {
-e.preventDefault();
-toggleCard();
-}
-});
-readBtn.addEventListener('click', (e) => {
-e.preventDefault();
-openReader(item);
-});
-return article;
-}
-function render() {
-const feedList = document.getElementById('feedList');
-const emptyMsg = document.getElementById('emptyMsg');
-batchDOM(() => {
-feedList.innerHTML = '';
-let filtered = STATE.items.filter(item => STATE.enabled.has(item.id));
+  const cardId = createCardId(item.link);
+  const isExpanded = STATE.expandedCards.has(cardId);
+  const isTrending = item.trendingScore > 5;
+  const article = document.createElement('article');
+  article.className = `card smooth${isExpanded ? ' open' : ''}${isTrending ? ' popular' : ''}`;
+  article.dataset.cardId = cardId;
 
-switch (STATE.view) {
-  case 'popular':
-    filtered = filtered
-      .sort((a, b) => b.trendingScore - a.trendingScore)
-      .slice(0, 30);
-    break;
-  case 'conservative':
-    filtered = filtered.filter(item => item.lane === 'conservative');
-    break;
-  case 'populist':
-    filtered = filtered.filter(item => item.lane === 'populist');
-    break;
-  case 'breaking':
-    filtered = filtered.filter(item => item.isBreaking);
-    break;
-  case 'by-source':
-    const grouped = {};
-    filtered.forEach(item => {
-      if (!grouped[item.source]) grouped[item.source] = [];
-      grouped[item.source].push(item);
-    });
-    
-    Object.keys(grouped).sort().forEach(sourceName => {
-      const header = document.createElement('div');
-      header.style.cssText = `
-        margin: 2rem 0 1rem;
-        font-size: 1rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        color: var(--accent);
-        padding-bottom: 0.5rem;
-        border-bottom: 1px solid var(--border);
-      `;
-      header.textContent = `${sourceName} (${grouped[sourceName].length})`;
-      feedList.appendChild(header);
-      
-      grouped[sourceName].slice(0, 10).forEach(item => {
-        feedList.appendChild(createCard(item));
+  let hostname = '';
+  try {
+    hostname = new URL(item.link).hostname;
+  } catch (error) {
+    hostname = '';
+  }
+
+  const timeString = fmtTime(item.pubDate);
+  const sentimentBadge = item.sentimentLabel
+    ? `<span class="badge sentiment ${item.sentimentTone}">${item.sentimentLabel}</span>`
+    : '';
+
+  article.innerHTML = `
+    <div class="card-head" tabindex="0" role="button" aria-expanded="${isExpanded}" aria-controls="body-${cardId}">
+      <span class="favicon" style="background-image:url('https://www.google.com/s2/favicons?domain=${hostname}&sz=64');" aria-hidden="true"></span>
+      <div>
+        <div class="titleline">
+          ${escapeHTML(item.title)}
+          ${item.isBreaking ? '<span class="breaking-indicator">BREAKING</span>' : ''}
+        </div>
+        <div class="tag">
+          ${escapeHTML(item.source)} • <span class="time">${timeString}</span>
+          ${isTrending ? '<span class="badge trending">TRENDING</span>' : ''}
+          ${sentimentBadge}
+        </div>
+      </div>
+      <div class="expand-btn" aria-hidden="true">${isExpanded ? '▼' : '▶'}</div>
+    </div>
+    <div class="card-body" id="body-${cardId}" role="region">
+      <div>${escapeHTML(item.desc || 'No summary available.')}</div>
+      <div class="card-actions">
+        <a href="${escapeHTML(item.link)}" target="_blank" rel="noopener" class="article-link smooth">
+          OPEN SOURCE
+        </a>
+        <button class="article-link read-btn smooth">READ HERE</button>
+      </div>
+    </div>
+  `;
+
+  const header = article.querySelector('.card-head');
+  const expandBtn = article.querySelector('.expand-btn');
+  const readBtn = article.querySelector('.read-btn');
+
+  const toggleCard = () => {
+    const isOpen = article.classList.toggle('open');
+    expandBtn.textContent = isOpen ? '▼' : '▶';
+    header.setAttribute('aria-expanded', String(isOpen));
+
+    if (isOpen) {
+      STATE.expandedCards.add(cardId);
+      document.querySelectorAll('.card.open').forEach(card => {
+        if (card !== article) {
+          card.classList.remove('open');
+          const otherBtn = card.querySelector('.expand-btn');
+          const otherHeader = card.querySelector('.card-head');
+          if (otherBtn) {
+            otherBtn.textContent = '▶';
+          }
+          if (otherHeader) {
+            otherHeader.setAttribute('aria-expanded', 'false');
+          }
+          STATE.expandedCards.delete(card.dataset.cardId);
+        }
       });
-    });
-    
-    emptyMsg.style.display = 'none';
-    return;
-}
-
-if (!filtered.length) {
-  emptyMsg.style.display = 'block';
-} else {
-  emptyMsg.style.display = 'none';
-  filtered.slice(0, 50).forEach(item => {
-    feedList.appendChild(createCard(item));
-  });
-}
-});
-}
-function buildSourceToggles() {
-const container = document.getElementById('sourceToggles');
-batchDOM(() => {
-container.innerHTML = '';
-SOURCES.forEach(source => {
-  const button = document.createElement('button');
-  button.className = 'src smooth' + (STATE.enabled.has(source.id) ? ' on' : '');
-  button.textContent = source.name;
-  button.dataset.id = source.id;
-  button.setAttribute('aria-pressed', STATE.enabled.has(source.id));
-
-  button.addEventListener('click', () => {
-    // Optimistic UI update
-    const wasEnabled = STATE.enabled.has(source.id);
-    
-    if (wasEnabled) {
-      STATE.enabled.delete(source.id);
     } else {
-      STATE.enabled.add(source.id);
+      STATE.expandedCards.delete(cardId);
     }
-    
-    if (STATE.enabled.size === 0) {
-      STATE.enabled = new Set([source.id]);
+
+    persistState();
+  };
+
+  header.addEventListener('click', toggleCard);
+  header.addEventListener('keydown', event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleCard();
     }
-    
-    button.classList.toggle('on');
-    button.setAttribute('aria-pressed', !wasEnabled);
-    
-    render();
-    saveEnabled();
   });
 
-  container.appendChild(button);
-});
-});
+  readBtn.addEventListener('click', event => {
+    event.preventDefault();
+    openReader(item);
+  });
+
+  return article;
 }
-// Keyboard navigation for filters
+
+function render() {
+  const feedList = document.getElementById('feedList');
+  const emptyMsg = document.getElementById('emptyMsg');
+
+  batchDOM(() => {
+    feedList.innerHTML = '';
+    let filtered = STATE.items.filter(item => STATE.enabled.has(item.id));
+
+    if (STATE.view === 'by-source') {
+      if (filtered.length === 0) {
+        emptyMsg.style.display = 'block';
+        return;
+      }
+
+      emptyMsg.style.display = 'none';
+      const grouped = new Map();
+      filtered.forEach(item => {
+        if (!grouped.has(item.source)) {
+          grouped.set(item.source, []);
+        }
+        grouped.get(item.source).push(item);
+      });
+
+      const fragment = document.createDocumentFragment();
+      Array.from(grouped.keys()).sort().forEach(sourceName => {
+        const header = document.createElement('div');
+        header.className = 'source-header';
+        header.textContent = sourceName;
+        fragment.appendChild(header);
+        grouped.get(sourceName).forEach(article => {
+          fragment.appendChild(createCard(article));
+        });
+      });
+
+      feedList.appendChild(fragment);
+      return;
+    }
+
+    switch (STATE.view) {
+      case 'popular':
+        filtered = filtered
+          .sort((a, b) => b.trendingScore - a.trendingScore)
+          .slice(0, 30);
+        break;
+      case 'conservative':
+        filtered = filtered.filter(item => item.lane === 'conservative');
+        break;
+      case 'populist':
+        filtered = filtered.filter(item => item.lane === 'populist');
+        break;
+      case 'breaking':
+        filtered = filtered.filter(item => item.isBreaking);
+        break;
+      default:
+        filtered = filtered.slice(0, 60);
+    }
+
+    if (filtered.length === 0) {
+      emptyMsg.style.display = 'block';
+      return;
+    }
+
+    emptyMsg.style.display = 'none';
+    const fragment = document.createDocumentFragment();
+    filtered.forEach(item => {
+      fragment.appendChild(createCard(item));
+    });
+    feedList.appendChild(fragment);
+  });
+}
+
+function buildSourceToggles() {
+  const container = document.getElementById('sourceToggles');
+  container.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+
+  SOURCES.forEach(source => {
+    const isEnabled = STATE.enabled.has(source.id);
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `src smooth${isEnabled ? ' on' : ''}`;
+    button.dataset.sourceId = source.id;
+    button.textContent = source.name;
+    button.setAttribute('aria-pressed', String(isEnabled));
+
+    button.addEventListener('click', () => {
+      const wasEnabled = STATE.enabled.has(source.id);
+      if (wasEnabled) {
+        STATE.enabled.delete(source.id);
+      } else {
+        STATE.enabled.add(source.id);
+      }
+
+      if (STATE.enabled.size === 0) {
+        STATE.enabled.add(source.id);
+      }
+
+      button.classList.toggle('on', !wasEnabled || STATE.enabled.has(source.id));
+      button.setAttribute('aria-pressed', String(STATE.enabled.has(source.id)));
+      persistState();
+      render();
+      if (!wasEnabled) {
+        loadFeeds();
+      }
+    });
+
+    fragment.appendChild(button);
+  });
+
+  container.appendChild(fragment);
+}
+
 function initFilterNavigation() {
-const filters = document.getElementById('filters');
-const chips = filters.querySelectorAll('.chip');
-filters.addEventListener('keydown', (e) => {
-const current = document.activeElement;
-const currentIndex = Array.from(chips).indexOf(current);
-let nextIndex = currentIndex;
+  const filters = document.getElementById('filters');
+  const chips = filters.querySelectorAll('.chip');
 
-switch(e.key) {
-  case 'ArrowRight':
-    nextIndex = (currentIndex + 1) % chips.length;
-    break;
-  case 'ArrowLeft':
-    nextIndex = (currentIndex - 1 + chips.length) % chips.length;
-    break;
-  case 'Home':
-    nextIndex = 0;
-    break;
-  case 'End':
-    nextIndex = chips.length - 1;
-    break;
-  default:
-    return;
+  filters.addEventListener('keydown', event => {
+    const current = document.activeElement;
+    const currentIndex = Array.from(chips).indexOf(current);
+    let nextIndex = currentIndex;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % chips.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + chips.length) % chips.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = chips.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    chips[nextIndex].focus();
+  });
 }
 
-e.preventDefault();
-chips[nextIndex].focus();
-});
-}
 function fmtTime(ts) {
-const d = new Date(ts);
-const diff = (Date.now() - d) / 1000;
-if (diff < 60) return 'NOW';
-if (diff < 3600) return Math.floor(diff / 60) + 'm';
-if (diff < 86400) return Math.floor(diff / 3600) + 'h';
-return Math.floor(diff / 86400) + 'd';
+  const date = new Date(ts);
+  const diffSeconds = (Date.now() - date.getTime()) / 1000;
+  if (diffSeconds < 60) {
+    return 'NOW';
+  }
+  if (diffSeconds < 3600) {
+    return `${Math.floor(diffSeconds / 60)}m`;
+  }
+  if (diffSeconds < 86400) {
+    return `${Math.floor(diffSeconds / 3600)}h`;
+  }
+  return `${Math.floor(diffSeconds / 86400)}d`;
 }
+
 function toast(msg, type = 'info') {
-const el = document.createElement('div');
-el.className = toast ${type} fade;
-el.textContent = msg;
-el.setAttribute('role', 'alert');
-document.body.appendChild(el);
-setTimeout(() => el.remove(), 2500);
-return el;
+  const el = document.createElement('div');
+  el.className = `toast ${type} fade`;
+  el.textContent = msg;
+  el.setAttribute('role', 'alert');
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 2500);
+  return el;
 }
+
 function escapeHTML(str = '') {
-const map = {'&':'&','<':'<','>':'>','"':'"',"'":'''};
-return str.replace(/[&<>"']/g, c => map[c]);
+  if (typeof str !== 'string') {
+    str = String(str || '');
+  }
+  return str.replace(/[&<>"']/g, char => ESCAPE_MAP[char]);
 }
-// Initialize
+
 document.addEventListener('DOMContentLoaded', () => {
-buildSourceToggles();
-initFilterNavigation();
-// Filter management with proper ARIA
-document.getElementById('filters').addEventListener('click', (e) => {
-const chip = e.target.closest('.chip');
-if (!chip) return;
-// Update ARIA states
-document.querySelectorAll('.chip').forEach(c => {
-  c.classList.remove('active');
-  c.setAttribute('aria-selected', 'false');
-  c.tabIndex = -1;
-});
+  buildSourceToggles();
+  initFilterNavigation();
 
-chip.classList.add('active');
-chip.setAttribute('aria-selected', 'true');
-chip.tabIndex = 0;
+  const filters = document.getElementById('filters');
+  filters.addEventListener('click', event => {
+    const chip = event.target.closest('.chip');
+    if (!chip) {
+      return;
+    }
 
-STATE.view = chip.dataset.view;
-render();
-});
-// Modal management with focus trapping
-const modal = document.getElementById('readerModal');
-const closeBtn = document.getElementById('readerClose');
-closeBtn.addEventListener('click', () => {
-modal.classList.remove('active');
-});
-// ESC key support
-document.addEventListener('keydown', (e) => {
-if (e.key === 'Escape' && modal.classList.contains('active')) {
-modal.classList.remove('active');
-}
-});
-document.getElementById('resetBtn').addEventListener('click', () => {
-if(confirm('Reset all settings and data?')) {
-localStorage.clear();
-location.reload();
-}
-});
-// Auto-refresh with better timing
-setInterval(() => {
-if (!STATE.loading && (Date.now() - STATE.lastFetch) > 120000) {
-loadFeeds();
-}
-}, 30000);
-// Initial load
-loadFeeds();
+    filters.querySelectorAll('.chip').forEach(element => {
+      element.classList.remove('active');
+      element.setAttribute('aria-selected', 'false');
+      element.tabIndex = -1;
+    });
+
+    chip.classList.add('active');
+    chip.setAttribute('aria-selected', 'true');
+    chip.tabIndex = 0;
+
+    STATE.view = chip.dataset.view;
+    render();
+  });
+
+  const modal = document.getElementById('readerModal');
+  const closeBtn = document.getElementById('readerClose');
+  closeBtn.addEventListener('click', () => {
+    modal.classList.remove('active');
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && modal.classList.contains('active')) {
+      modal.classList.remove('active');
+    }
+  });
+
+  document.getElementById('resetBtn').addEventListener('click', () => {
+    if (confirm('Reset all settings and data?')) {
+      localStorage.clear();
+      location.reload();
+    }
+  });
+
+  setInterval(() => {
+    if (!STATE.loading && Date.now() - STATE.lastFetch > 120000) {
+      loadFeeds();
+    }
+  }, 30000);
+
+  loadFeeds();
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- rebuild the feed loading pipeline with resilient proxy fetches, caching, and safe persistence so feeds populate instead of hanging on initialization
- add lightweight sentiment analysis for each article and render a one-word badge with new styling alongside existing metadata
- streamline rendering for grouped views and source toggles to keep the UI responsive when switching filters

## Testing
- node -e 'const fs=require("fs");const m=fs.readFileSync("index.html","utf8").match(/<script>([\\s\\S]*)<\\/script>/);if(!m)throw new Error("script missing");new Function(m[1]);'

------
https://chatgpt.com/codex/tasks/task_e_68c9b38aac0c832690390b458eebe7f7