### PR TITLE
Add mainstream feeds and bias meter

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@ CHANGELOG:
     --aurora-1: #40d9ff;
     --aurora-2: #7a5bff;
     --aurora-3: #4ef4c2;
+    --bias-left: #2f6bff;
+    --bias-center: #9ba9c8;
+    --bias-right: #ff5f5f;
   }
   
   * {
@@ -183,7 +186,11 @@ CHANGELOG:
     display: flex;
     gap: 0.5rem;
     overflow-x: auto;
-    padding: 0 1rem 1rem;
+    padding: 0.75rem 1rem 1rem;
+    background: linear-gradient(180deg, rgba(5, 7, 13, 0.97), rgba(5, 7, 13, 0.92));
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 30px rgba(5, 7, 13, 0.55);
     scrollbar-width: none;
     -ms-overflow-style: none;
   }
@@ -455,9 +462,108 @@ CHANGELOG:
     border-top: 1px solid var(--border);
     word-wrap: break-word;
   }
-  
+
   .card.open .card-body {
     display: block;
+  }
+
+  .card-body > * + * {
+    margin-top: 1rem;
+  }
+
+  .bias-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .bias-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .bias-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .bias-label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+  }
+
+  .bias-label.left {
+    color: var(--bias-left);
+  }
+
+  .bias-label.left-soft {
+    color: #5f8bff;
+  }
+
+  .bias-label.center {
+    color: var(--bias-center);
+  }
+
+  .bias-label.right-soft {
+    color: #ff7d7d;
+  }
+
+  .bias-label.right {
+    color: var(--bias-right);
+  }
+
+  .bias-meter {
+    position: relative;
+    height: 32px;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: linear-gradient(90deg, rgba(47, 107, 255, 0.85) 0%, rgba(47, 107, 255, 0.65) 20%, rgba(155, 169, 200, 0.8) 50%, rgba(255, 95, 95, 0.65) 80%, rgba(255, 95, 95, 0.85) 100%);
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.45);
+  }
+
+  .bias-indicator {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    pointer-events: none;
+  }
+
+  .bias-symbol {
+    font-size: 1rem;
+    color: #ffffff;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.55);
+  }
+
+  .bias-score {
+    font-size: 0.65rem;
+    font-weight: 700;
+    background: rgba(2, 3, 5, 0.78);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    letter-spacing: 0.4px;
+    color: var(--text);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.35);
+  }
+
+  .bias-scale-labels {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.65rem;
+    letter-spacing: 0.3px;
+    color: var(--muted);
+    text-transform: uppercase;
   }
 
   .card-actions {
@@ -674,15 +780,23 @@ CHANGELOG:
     .title {
       font-size: 1rem;
     }
-    
+
     .filters {
       padding: 0 0.8rem 0.8rem;
       gap: 0.3rem;
     }
-    
+
     .chip {
       padding: 0.4rem 0.6rem;
       font-size: 0.7rem;
+    }
+
+    .bias-meter {
+      height: 26px;
+    }
+
+    .bias-score {
+      font-size: 0.58rem;
     }
   }
 
@@ -756,7 +870,10 @@ const SOURCES = [
   { id: 'townhall', name: 'Townhall', url: 'https://townhall.com/rss', lane: 'conservative' },
   { id: 'foxnews', name: 'Fox News', url: 'https://feeds.foxnews.com/foxnews/latest', lane: 'conservative' },
   { id: 'washexam', name: 'Washington Examiner', url: 'https://www.washingtonexaminer.com/feed', lane: 'conservative' },
-  { id: 'theblaze', name: 'The Blaze', url: 'https://www.theblaze.com/feeds/latest.rss', lane: 'conservative' }
+  { id: 'theblaze', name: 'The Blaze', url: 'https://www.theblaze.com/feeds/latest.rss', lane: 'conservative' },
+  { id: 'nbcnews', name: 'NBC News', url: 'https://feeds.nbcnews.com/nbcnews/public/news', lane: 'mainstream' },
+  { id: 'abcnews', name: 'ABC News', url: 'https://abcnews.go.com/abcnews/topstories', lane: 'mainstream' },
+  { id: 'cnn', name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss', lane: 'mainstream' }
 ];
 
 const persistedState = loadPersistedState();
@@ -919,6 +1036,98 @@ const BOOSTER_WORDS = new Set(['very', 'extremely', 'highly', 'truly', 'deeply',
 const DAMPENER_WORDS = new Set(['slightly', 'barely', 'somewhat', 'mildly', 'modestly', 'partially']);
 const NEGATION_WORDS = new Set(['no', 'not', 'never', 'without', 'hardly', 'rarely', 'scarcely', 'neither']);
 
+const BIAS_SOURCE_BASE = {
+  conservative: 2,
+  populist: 3,
+  mainstream: 0
+};
+
+const BIAS_RANGE = 10;
+
+const BIAS_PHRASES = [
+  { pattern: /climate (?:crisis|change)/i, weight: -2.4 },
+  { pattern: /carbon emissions/i, weight: -2.1 },
+  { pattern: /clean energy/i, weight: -1.8 },
+  { pattern: /green energy/i, weight: -2 },
+  { pattern: /renewable energy/i, weight: -2.2 },
+  { pattern: /gun control/i, weight: -2.6 },
+  { pattern: /racial justice/i, weight: -2.2 },
+  { pattern: /reproductive rights/i, weight: -2.5 },
+  { pattern: /abortion rights/i, weight: -2.4 },
+  { pattern: /medicare for all/i, weight: -3 },
+  { pattern: /universal health care/i, weight: -2.6 },
+  { pattern: /student loan (?:forgiveness|relief)/i, weight: -2.1 },
+  { pattern: /voting rights/i, weight: -1.7 },
+  { pattern: /police reform/i, weight: -1.8 },
+  { pattern: /criminal justice reform/i, weight: -1.8 },
+  { pattern: /lgbtq rights/i, weight: -2.1 },
+  { pattern: /trans rights/i, weight: -2.1 },
+  { pattern: /marriage equality/i, weight: -2 },
+  { pattern: /border security/i, weight: 2.5 },
+  { pattern: /border wall/i, weight: 3 },
+  { pattern: /illegal immigration/i, weight: 2.5 },
+  { pattern: /secure the border/i, weight: 2.8 },
+  { pattern: /america first/i, weight: 2.6 },
+  { pattern: /law and order/i, weight: 2.3 },
+  { pattern: /second amendment/i, weight: 3 },
+  { pattern: /gun rights/i, weight: 2.4 },
+  { pattern: /right to life/i, weight: 2.4 },
+  { pattern: /pro-life/i, weight: 2.2 },
+  { pattern: /religious liberty/i, weight: 2 },
+  { pattern: /parental rights/i, weight: 2.1 },
+  { pattern: /school choice/i, weight: 2.2 },
+  { pattern: /limited government/i, weight: 2.2 },
+  { pattern: /small government/i, weight: 2.2 },
+  { pattern: /tax (?:cuts|cut)/i, weight: 1.8 },
+  { pattern: /energy independence/i, weight: 1.7 },
+  { pattern: /anti-woke/i, weight: 2 },
+  { pattern: /woke agenda/i, weight: 2.1 }
+];
+
+const BIAS_KEYWORDS = new Map([
+  ['progressive', -1.6],
+  ['progressives', -1.6],
+  ['liberal', -1.4],
+  ['liberals', -1.4],
+  ['democrat', -1.1],
+  ['democrats', -1.1],
+  ['biden', -0.8],
+  ['harris', -0.7],
+  ['climate', -1.3],
+  ['emissions', -1.2],
+  ['renewable', -1.1],
+  ['sustainable', -1],
+  ['equity', -1.3],
+  ['diversity', -1.2],
+  ['inclusion', -1.1],
+  ['inclusive', -1],
+  ['lgbtq', -1.4],
+  ['transgender', -1.5],
+  ['abortion', -0.9],
+  ['reproductive', -1.3],
+  ['union', -1],
+  ['unions', -1],
+  ['conservative', 1.5],
+  ['conservatives', 1.5],
+  ['republican', 1.2],
+  ['republicans', 1.2],
+  ['trump', 1.2],
+  ['desantis', 1],
+  ['patriot', 1.8],
+  ['patriots', 1.6],
+  ['liberty', 1.2],
+  ['freedom', 1],
+  ['border', 1.4],
+  ['woke', 1.6],
+  ['christian', 1.2],
+  ['faith', 0.9],
+  ['gun', 0.8],
+  ['guns', 0.8],
+  ['patriotic', 1.4],
+  ['nationalist', 1.6],
+  ['sovereignty', 1.3]
+]);
+
 const CLICKBAIT_PATTERNS = [
   /you won't believe/i,
   /you will not believe/i,
@@ -937,7 +1146,21 @@ const CLICKBAIT_PATTERNS = [
   /epic/i,
   /unbelievable/i,
   /life[-\s]?changing/i,
-  /top \d+ (things|reasons|ways|tricks|hacks)/i
+  /top \d+ (things|reasons|ways|tricks|hacks)/i,
+  /mind[-\s]?blowing/i,
+  /game[-\s]?changer/i,
+  /bombshell/i,
+  /one weird trick/i,
+  /this changes everything/i,
+  /must[-\s]?read/i,
+  /must[-\s]?watch/i,
+  /can't believe/i,
+  /mic drop/i,
+  /claps? back/i,
+  /goes off on/i,
+  /freaks out/i,
+  /meltdown/i,
+  /epic fail/i
 ];
 
 const NON_NEWS_PATTERNS = [
@@ -1225,6 +1448,77 @@ function analyzeSentiment(item) {
   return { label: descriptor.label, tone: descriptor.tone, score };
 }
 
+function describeBias(score) {
+  if (score <= -4.5) {
+    return { label: 'Leans Left', className: 'left' };
+  }
+  if (score < -1.5) {
+    return { label: 'Left of Center', className: 'left-soft' };
+  }
+  if (score <= 1.5) {
+    return { label: 'Center', className: 'center' };
+  }
+  if (score < 4.5) {
+    return { label: 'Right of Center', className: 'right-soft' };
+  }
+  return { label: 'Leans Right', className: 'right' };
+}
+
+function formatBiasScore(score = 0) {
+  if (typeof score !== 'number' || Number.isNaN(score)) {
+    return '0.0';
+  }
+  const rounded = Math.round(score * 10) / 10;
+  return `${rounded > 0 ? '+' : ''}${rounded.toFixed(1)}`;
+}
+
+function biasScoreToPercent(score = 0) {
+  const normalized = ((score + BIAS_RANGE) / (BIAS_RANGE * 2)) * 100;
+  return Math.max(0, Math.min(100, normalized));
+}
+
+function analyzeBias(item) {
+  const text = `${item.title || ''} ${item.desc || ''}`.toLowerCase();
+  let score = BIAS_SOURCE_BASE[item.lane] || 0;
+
+  BIAS_PHRASES.forEach(({ pattern, weight }) => {
+    if (pattern.test(text)) {
+      score += weight;
+    }
+  });
+
+  const tokens = new Set(text.match(/\b[a-z]{3,}\b/g) || []);
+  tokens.forEach(token => {
+    if (BIAS_KEYWORDS.has(token)) {
+      score += BIAS_KEYWORDS.get(token);
+    }
+  });
+
+  if (/fact[-\s]?check/i.test(text)) {
+    score -= 1.4;
+  }
+
+  if (/hunter biden/i.test(text)) {
+    score += 1.4;
+  }
+
+  if (/white house/i.test(text)) {
+    score -= 0.4;
+  }
+
+  const bounded = Math.max(-BIAS_RANGE, Math.min(BIAS_RANGE, score));
+  const descriptor = describeBias(bounded);
+  const displayScore = Number(bounded.toFixed(2));
+  const percent = Math.min(98, Math.max(2, biasScoreToPercent(displayScore)));
+
+  return {
+    score: displayScore,
+    label: descriptor.label,
+    className: descriptor.className,
+    percent
+  };
+}
+
 function createCardId(link) {
   let hash = 0;
   for (let i = 0; i < link.length; i += 1) {
@@ -1277,6 +1571,10 @@ function isLikelyNews(item) {
 
   const description = (item.desc || '').trim();
   const combined = `${title} ${description}`.toLowerCase();
+
+  if (/\?{2,}/.test(title) || /!{2,}/.test(title)) {
+    return false;
+  }
 
   if (CLICKBAIT_PATTERNS.some(pattern => pattern.test(combined))) {
     return false;
@@ -1367,6 +1665,12 @@ async function loadFeeds() {
       item.sentimentScore = Number(sentiment.score.toFixed(2));
       item.sentimentLabel = sentiment.label;
       item.sentimentTone = sentiment.tone;
+
+      const bias = analyzeBias(item);
+      item.biasScore = bias.score;
+      item.biasLabel = bias.label;
+      item.biasClass = bias.className;
+      item.biasPercent = bias.percent;
     });
 
     render();
@@ -1403,6 +1707,15 @@ function createCard(item) {
   const sentimentBadge = item.sentimentLabel
     ? `<span class="badge sentiment ${item.sentimentTone}" title="Sentiment score ${formatSentimentScore(item.sentimentScore)}">${escapeHTML(item.sentimentLabel)} • ${formatSentimentScore(item.sentimentScore)}</span>`
     : '';
+  const biasLabel = item.biasLabel || 'Center';
+  const biasClass = item.biasClass || 'center';
+  const biasScore = typeof item.biasScore === 'number' && !Number.isNaN(item.biasScore) ? item.biasScore : 0;
+  const biasScoreFormatted = formatBiasScore(biasScore);
+  const biasPercent = Number.isFinite(item.biasPercent) ? item.biasPercent : 50;
+  const biasPosition = Math.max(2, Math.min(98, Math.round(biasPercent * 10) / 10));
+  const biasLabelSafe = escapeHTML(biasLabel);
+  const biasAriaText = `Political lean ${biasLabel} with score ${biasScoreFormatted}`;
+  const biasAria = escapeHTML(biasAriaText);
 
   article.innerHTML = `
     <div class="card-head" tabindex="0" role="button" aria-expanded="${isExpanded}" aria-controls="body-${cardId}">
@@ -1421,6 +1734,24 @@ function createCard(item) {
       <div class="expand-btn" aria-hidden="true">${isExpanded ? '▼' : '▶'}</div>
     </div>
     <div class="card-body" id="body-${cardId}" role="region">
+      <div class="bias-section" aria-label="${biasAria}">
+        <div class="bias-header">
+          <span class="bias-title">Political Lean</span>
+          <span class="bias-label ${biasClass}">${biasLabelSafe}</span>
+        </div>
+        <div class="bias-meter" role="img" aria-label="${biasAria}">
+          <div class="bias-indicator" style="left:${biasPosition}%;">
+            <span class="bias-symbol" aria-hidden="true">◆</span>
+            <span class="bias-score" aria-hidden="true">${biasScoreFormatted}</span>
+          </div>
+          <span class="sr-only">${biasAria}</span>
+        </div>
+        <div class="bias-scale-labels" aria-hidden="true">
+          <span>LEFT</span>
+          <span>CENTER</span>
+          <span>RIGHT</span>
+        </div>
+      </div>
       <div>${escapeHTML(item.desc || 'No summary available.')}</div>
       <div class="card-actions">
         <a href="${escapeHTML(item.link)}" target="_blank" rel="noopener" class="article-link smooth">


### PR DESCRIPTION
## Summary
- keep the filter chip bar opaque during scroll so the controls stay legible
- add political lean scoring with a blue-to-red meter inside article details
- pull in additional mainstream sources and tighten clickbait filtering heuristics

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9c49b01988326aa89be2ed659b9ee