### PR TITLE
Refine layout and streamline cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,8 @@ CHANGELOG:
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
+    row-gap: 0.35rem;
   }
   
   .blip {
@@ -675,35 +677,6 @@ CHANGELOG:
     color: var(--err);
   }
 
-  /* Reset button */
-  .btn.reset {
-    border: 1px solid var(--warn);
-    background: var(--panel);
-    color: var(--warn);
-    padding: 0.6rem 0.8rem;
-    border-radius: 6px;
-    font-weight: 600;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    font-family: inherit;
-    cursor: pointer;
-    position: fixed;
-    bottom: 1rem;
-    right: 1rem;
-    z-index: 100;
-  }
-  
-  .btn.reset:hover {
-    background: var(--warn);
-    color: var(--bg);
-  }
-
-  .btn.reset:focus-visible {
-    outline: 2px solid var(--warn);
-    outline-offset: 2px;
-  }
-
   /* Source toggles */
   .src-grid {
     display: flex;
@@ -922,13 +895,18 @@ CHANGELOG:
     position: sticky;
     top: calc(env(safe-area-inset-top) + 3.25rem);
     display: flex;
-    justify-content: center;
+    align-items: center;
+    justify-content: flex-start;
     padding: 0.85rem 1.5rem;
-    gap: 0.35rem;
+    gap: 0.75rem;
     background: transparent;
     border: none;
     box-shadow: none;
-    overflow: visible;
+    overflow-x: auto;
+    overflow-y: hidden;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
 
   .filters::before {
@@ -948,10 +926,8 @@ CHANGELOG:
 
   .chip {
     position: relative;
-    flex: 1;
-    min-width: 110px;
-    max-width: 160px;
-    padding: 0.55rem 0.75rem;
+    flex: 0 0 auto;
+    padding: 0.55rem 1rem;
     border-radius: 15px;
     border: none;
     background: transparent;
@@ -960,9 +936,10 @@ CHANGELOG:
     letter-spacing: 0.18em;
     text-transform: uppercase;
     font-weight: 600;
-    justify-content: center;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    white-space: nowrap;
     transition: color 0.3s var(--ios-ease), transform 0.35s var(--ios-ease);
   }
 
@@ -1199,7 +1176,7 @@ CHANGELOG:
   .sentiment-panel {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: center;
     gap: 1rem;
     background: rgba(255, 255, 255, 0.02);
     border-radius: 16px;
@@ -1207,36 +1184,50 @@ CHANGELOG:
     padding: 1rem 1.2rem;
   }
 
-  .sentiment-trend {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
+  .sentiment-summary {
+    display: grid;
+    gap: 0.4rem;
   }
 
-  .sparkline {
-    width: 100%;
-    height: 56px;
-  }
-
-  .sparkline__stroke {
-    fill: none;
-    stroke: var(--accent);
-    stroke-width: 2;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    filter: drop-shadow(0 6px 12px rgba(64, 217, 255, 0.18));
-  }
-
-  .sparkline__fill {
-    fill: rgba(64, 217, 255, 0.16);
-    stroke: none;
-  }
-
-  .sentiment-trend__caption {
+  .sentiment-summary__label {
     font-size: 0.65rem;
     letter-spacing: 0.2em;
     text-transform: uppercase;
     color: rgba(255, 255, 255, 0.55);
+  }
+
+  .sentiment-summary__value {
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .sentiment-summary__value--very-positive {
+    color: var(--tone-high);
+  }
+
+  .sentiment-summary__value--positive {
+    color: var(--tone-mid);
+  }
+
+  .sentiment-summary__value--neutral {
+    color: var(--tone-neutral);
+  }
+
+  .sentiment-summary__value--negative {
+    color: var(--tone-low);
+  }
+
+  .sentiment-summary__value--very-negative {
+    color: var(--tone-critical);
+  }
+
+  .sentiment-summary__score {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.65);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
   }
 
   .credibility-row {
@@ -1360,26 +1351,6 @@ CHANGELOG:
   .tab-bar__icon {
     font-size: 1.1rem;
     line-height: 1;
-  }
-
-  .btn.reset {
-    position: fixed;
-    top: calc(env(safe-area-inset-top) + 0.75rem);
-    right: 1rem;
-    background: rgba(8, 12, 20, 0.82);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    color: var(--text);
-    padding: 0.55rem 0.9rem;
-    border-radius: 16px;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    font-weight: 600;
-    box-shadow: 0 16px 30px rgba(8, 12, 20, 0.55);
-  }
-
-  .btn.reset:hover {
-    background: rgba(64, 217, 255, 0.16);
-    color: var(--accent);
   }
 
   .action-sheet {
@@ -1596,13 +1567,20 @@ CHANGELOG:
     <span class="tab-bar__icon">!</span>
     <span class="tab-bar__label">Breaking</span>
   </button>
-  <button type="button" class="tab-bar__btn" data-sheet-trigger="true" role="tab" aria-selected="false">
+  <button
+    type="button"
+    class="tab-bar__btn"
+    id="moreActionsTrigger"
+    data-sheet-trigger="true"
+    role="tab"
+    aria-selected="false"
+    aria-haspopup="dialog"
+    aria-expanded="false"
+  >
     <span class="tab-bar__icon">⋯</span>
     <span class="tab-bar__label">More</span>
   </button>
 </nav>
-
-<button class="btn reset smooth" id="resetBtn" title="Action menu" aria-haspopup="dialog" aria-expanded="false">ACTIONS</button>
 
 <div class="action-sheet" id="actionSheet" role="dialog" aria-modal="true" hidden>
   <div class="action-sheet__overlay" data-sheet-close></div>
@@ -1791,47 +1769,6 @@ function getCredibility(item) {
   };
 }
 
-function seededRandom(seed) {
-  let hash = 2166136261;
-  for (let i = 0; i < seed.length; i += 1) {
-    hash ^= seed.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  hash += hash << 13;
-  hash ^= hash >> 7;
-  hash += hash << 3;
-  hash ^= hash >> 17;
-  hash += hash << 5;
-  return ((hash >>> 0) % 1000) / 1000;
-}
-
-function buildSparkline(cardId, item) {
-  const width = 120;
-  const height = 36;
-  const count = 12;
-  const sentiment = Number(item.sentimentScore) || 0;
-  const base = 0.5 + clamp(sentiment, -10, 10) / 24;
-  const slope = clamp((Number(item.trendingScore) || 0) / 20, -0.2, 0.2) * 0.2;
-  const strokePoints = [];
-
-  for (let i = 0; i < count; i += 1) {
-    const progress = i / (count - 1);
-    const noise = seededRandom(`${cardId}-${i}`) * 0.36 - 0.18;
-    const value = clamp(base + noise + slope * (progress - 0.5), 0.08, 0.92);
-    const x = (width / (count - 1)) * i;
-    const y = height - value * (height - 6) - 3;
-    strokePoints.push(`${x.toFixed(1)},${y.toFixed(1)}`);
-  }
-
-  const fillPoints = ['0,36', ...strokePoints, `${width},36`];
-
-  return {
-    stroke: strokePoints.join(' '),
-    fill: fillPoints.join(' '),
-    caption: `Sentiment ${formatSentimentScore(sentiment)}`
-  };
-}
-
 let pullIndicatorTimer = null;
 
 function updatePullIndicator(state, text, hideDelay = 1400) {
@@ -1926,7 +1863,12 @@ function setupTabBar() {
     }
 
     if (button.hasAttribute('data-sheet-trigger')) {
-      openActionSheet();
+      const sheet = document.getElementById('actionSheet');
+      if (sheet?.classList.contains('is-visible')) {
+        closeActionSheet();
+      } else {
+        openActionSheet(button);
+      }
       return;
     }
 
@@ -1972,19 +1914,27 @@ function setupTabBar() {
 }
 
 let actionSheetHideTimer = null;
+let actionSheetTriggerEl = null;
 
-function openActionSheet() {
+function openActionSheet(trigger) {
   const sheet = document.getElementById('actionSheet');
-  const trigger = document.getElementById('resetBtn');
   if (!sheet) {
     return;
   }
 
+  if (actionSheetHideTimer) {
+    clearTimeout(actionSheetHideTimer);
+    actionSheetHideTimer = null;
+  }
+
+  actionSheetTriggerEl = trigger || actionSheetTriggerEl || document.getElementById('moreActionsTrigger');
+
   sheet.hidden = false;
   sheet.classList.add('is-visible');
   sheet.setAttribute('aria-hidden', 'false');
-  if (trigger) {
-    trigger.setAttribute('aria-expanded', 'true');
+
+  if (actionSheetTriggerEl) {
+    actionSheetTriggerEl.setAttribute('aria-expanded', 'true');
   }
 
   const firstAction = sheet.querySelector('[data-sheet-action]');
@@ -1997,16 +1947,16 @@ function openActionSheet() {
 
 function closeActionSheet() {
   const sheet = document.getElementById('actionSheet');
-  const trigger = document.getElementById('resetBtn');
   if (!sheet || sheet.hidden) {
     return;
   }
 
   sheet.classList.remove('is-visible');
   sheet.setAttribute('aria-hidden', 'true');
-  if (trigger) {
-    trigger.setAttribute('aria-expanded', 'false');
-    trigger.focus({ preventScroll: true });
+
+  if (actionSheetTriggerEl) {
+    actionSheetTriggerEl.setAttribute('aria-expanded', 'false');
+    actionSheetTriggerEl.focus({ preventScroll: true });
   }
 
   if (actionSheetHideTimer) {
@@ -2050,19 +2000,9 @@ function performReset() {
 
 function setupActionSheet() {
   const sheet = document.getElementById('actionSheet');
-  const trigger = document.getElementById('resetBtn');
-  if (!sheet || !trigger) {
+  if (!sheet) {
     return;
   }
-
-  trigger.addEventListener('click', event => {
-    event.preventDefault();
-    if (sheet.hidden) {
-      openActionSheet();
-    } else {
-      closeActionSheet();
-    }
-  });
 
   sheet.addEventListener('click', event => {
     const closeTarget = event.target.closest('[data-sheet-close]');
@@ -3029,7 +2969,12 @@ function createCard(item, index = 0, total = 1) {
   const isFresh = isFreshStory(item);
   const importance = determineImportance(item, index);
   const credibility = getCredibility(item);
-  const sparkline = buildSparkline(cardId, item);
+  const sentimentTone = ['very-positive', 'positive', 'neutral', 'negative', 'very-negative'].includes(item.sentimentTone)
+    ? item.sentimentTone
+    : 'neutral';
+  const sentimentSummaryClass = ` sentiment-summary__value--${sentimentTone}`;
+  const sentimentScoreFormatted = formatSentimentScore(item.sentimentScore);
+  const sentimentLabelText = escapeHTML(item.sentimentLabel || 'STEADY');
   const progressValue = getReadProgress(cardId);
 
   const article = document.createElement('article');
@@ -3064,7 +3009,7 @@ function createCard(item, index = 0, total = 1) {
 
   const timeString = fmtTime(item.pubDate);
   const sentimentBadge = item.sentimentLabel
-    ? `<span class="badge sentiment ${item.sentimentTone}" title="Sentiment score ${formatSentimentScore(item.sentimentScore)}">${escapeHTML(item.sentimentLabel)} • ${formatSentimentScore(item.sentimentScore)}</span>`
+    ? `<span class="badge sentiment ${item.sentimentTone}" title="Sentiment score ${sentimentScoreFormatted}">${escapeHTML(item.sentimentLabel)} • ${sentimentScoreFormatted}</span>`
     : '';
   const biasLabel = item.biasLabel || 'Center';
   const biasClass = item.biasClass || 'center';
@@ -3122,12 +3067,10 @@ function createCard(item, index = 0, total = 1) {
           </div>
         </div>
         <div class="sentiment-panel" aria-label="Sentiment and credibility insights">
-          <div class="sentiment-trend" aria-hidden="true">
-            <svg class="sparkline" viewBox="0 0 120 36" preserveAspectRatio="none">
-              <polygon class="sparkline__fill" points="${sparkline.fill}"></polygon>
-              <polyline class="sparkline__stroke" points="${sparkline.stroke}"></polyline>
-            </svg>
-            <span class="sentiment-trend__caption">${escapeHTML(sparkline.caption)}</span>
+          <div class="sentiment-summary">
+            <span class="sentiment-summary__label">Sentiment</span>
+            <span class="sentiment-summary__value${sentimentSummaryClass}">${sentimentLabelText}</span>
+            <span class="sentiment-summary__score">Score ${sentimentScoreFormatted}</span>
           </div>
           <div class="credibility-row">
             <strong>${escapeHTML(credibility.detail)}</strong>


### PR DESCRIPTION
## Summary
- remove the standalone Actions button and wire the tab bar "More" control to open and close the action sheet with correct focus handling
- fix header spacing so the title can wrap and the filter chips scroll horizontally instead of overlapping
- drop the sparkline graphic from each card and replace it with a compact textual sentiment summary and updated styling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e143f3488326a6cdb622fc21054b