### PR TITLE
Restyle article cards and replace bias meter with badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,8 +128,9 @@ CHANGELOG:
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: var(--ok);
+    background: var(--accent);
     flex-shrink: 0;
+    box-shadow: 0 0 0 2px rgba(64, 217, 255, 0.24), 0 0 10px rgba(64, 217, 255, 0.55);
   }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -246,13 +247,14 @@ CHANGELOG:
   
   /* Cards */
   .card {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 12px;
+    background: linear-gradient(175deg, rgba(12, 18, 30, 0.9), rgba(4, 6, 14, 0.94));
+    border: 1px solid rgba(64, 217, 255, 0.14);
+    border-radius: 18px;
     overflow: hidden;
-    margin-bottom: 1rem;
+    margin-bottom: 1.2rem;
     position: relative;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+    box-shadow: 0 20px 48px rgba(4, 6, 12, 0.6);
   }
 
   .card::before {
@@ -303,10 +305,10 @@ CHANGELOG:
 
   .card-head {
     display: grid;
-    grid-template-columns: auto 1fr auto;
-    gap: 0.8rem;
-    align-items: flex-start;
-    padding: 1rem;
+    grid-template-columns: auto 1fr auto auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 1.1rem 1.4rem;
     cursor: pointer;
   }
   
@@ -405,6 +407,49 @@ CHANGELOG:
     color: var(--tone-critical);
   }
 
+  .badge.bias {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.75rem;
+    background: rgba(64, 217, 255, 0.08);
+    border-color: rgba(64, 217, 255, 0.32);
+    color: var(--accent);
+    text-transform: none;
+    letter-spacing: 0.08em;
+  }
+
+  .badge.bias .badge-bias__value {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.8;
+  }
+
+  .badge.bias .badge-bias__value::before {
+    content: '•';
+    margin-right: 0.25rem;
+    opacity: 0.65;
+  }
+
+  .badge.bias.left,
+  .badge.bias.left-soft {
+    color: var(--bias-left);
+    border-color: rgba(47, 107, 255, 0.38);
+    background: rgba(47, 107, 255, 0.14);
+  }
+
+  .badge.bias.center {
+    color: var(--bias-center);
+    border-color: rgba(155, 169, 200, 0.35);
+    background: rgba(155, 169, 200, 0.12);
+  }
+
+  .badge.bias.right,
+  .badge.bias.right-soft {
+    color: var(--bias-right);
+    border-color: rgba(255, 95, 95, 0.4);
+    background: rgba(255, 95, 95, 0.14);
+  }
+
   .breaking-indicator {
     display: inline-block;
     background: var(--err);
@@ -472,126 +517,31 @@ CHANGELOG:
   .bias-section {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.6rem;
+    align-items: flex-start;
   }
 
   .bias-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
+    gap: 1rem;
+    width: 100%;
   }
 
   .bias-title {
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     font-weight: 700;
-    letter-spacing: 0.3px;
+    letter-spacing: 0.24em;
     text-transform: uppercase;
-    color: var(--muted);
+    color: rgba(255, 255, 255, 0.58);
   }
 
-  .bias-label {
-    font-size: 0.8rem;
-    font-weight: 700;
-    letter-spacing: 0.3px;
-  }
-
-  .bias-label.left {
-    color: var(--bias-left);
-  }
-
-  .bias-label.left-soft {
-    color: #5f8bff;
-  }
-
-  .bias-label.center {
-    color: var(--bias-center);
-  }
-
-  .bias-label.right-soft {
-    color: #ff7d7d;
-  }
-
-  .bias-label.right {
-    color: var(--bias-right);
-  }
-
-  .bias-meter {
-    position: relative;
-    height: 14px;
-    border-radius: 999px;
-    overflow: visible;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: linear-gradient(
-      90deg,
-      rgba(47, 107, 255, 0.4) 0%,
-      rgba(47, 107, 255, 0.28) 20%,
-      rgba(155, 169, 200, 0.38) 50%,
-      rgba(255, 95, 95, 0.28) 80%,
-      rgba(255, 95, 95, 0.4) 100%
-    );
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.45);
-  }
-
-  .bias-indicator {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    transform: translateX(-50%);
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
-    pointer-events: none;
-  }
-
-  .bias-score {
-    position: absolute;
-    bottom: calc(100% + 0.35rem);
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0.72rem;
-    font-weight: 700;
-    background: rgba(5, 7, 13, 0.92);
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
-    letter-spacing: 0.35px;
-    color: var(--text);
-    border: 1px solid rgba(255, 255, 255, 0.18);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
-    white-space: nowrap;
-  }
-
-  .bias-marker {
-    position: relative;
-    width: 3px;
-    height: 100%;
-    border-radius: 999px;
-    background: var(--text);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45);
-  }
-
-  .bias-marker::after {
-    content: '';
-    position: absolute;
-    top: -6px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--text);
-    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.45);
-  }
-
-  .bias-scale-labels {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: 0.65rem;
-    letter-spacing: 0.3px;
-    color: var(--muted);
-    text-transform: uppercase;
-    margin-top: 0.75rem;
+  .bias-description {
+    margin: 0;
+    font-size: 0.74rem;
+    letter-spacing: 0.06em;
+    color: rgba(255, 255, 255, 0.55);
   }
 
   .card-actions {
@@ -744,18 +694,15 @@ CHANGELOG:
       font-size: 0.7rem;
     }
 
-    .bias-meter {
-      height: 12px;
+    .bias-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.5rem;
     }
 
-    .bias-score {
-      font-size: 0.64rem;
-      padding: 0.16rem 0.45rem;
-    }
-
-    .bias-marker::after {
-      width: 8px;
-      height: 8px;
+    .badge.bias {
+      width: 100%;
+      justify-content: space-between;
     }
   }
 
@@ -916,16 +863,16 @@ CHANGELOG:
   .card {
     position: relative;
     border-radius: 22px;
-    border: 1px solid rgba(255, 255, 255, 0.04);
-    background: linear-gradient(165deg, rgba(12, 18, 28, 0.92), rgba(4, 6, 12, 0.92));
-    box-shadow: 0 20px 48px rgba(4, 6, 12, 0.65);
+    border: 1px solid rgba(64, 217, 255, 0.14);
+    background: linear-gradient(170deg, rgba(12, 18, 30, 0.9), rgba(4, 6, 14, 0.94));
+    box-shadow: 0 24px 60px rgba(4, 6, 12, 0.66);
     overflow: hidden;
     margin: 0;
     transform-origin: center top;
     transform: translateY(var(--stack-offset, 0px)) scale(var(--stack-scale, 1));
     transition: transform 0.6s var(--ios-ease), box-shadow 0.45s var(--ios-ease), border-color 0.4s ease, background 0.4s ease;
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     animation: cardStackIn 0.7s var(--ios-ease) both;
     animation-delay: var(--card-delay, 0s);
   }
@@ -1037,6 +984,53 @@ CHANGELOG:
     letter-spacing: 0.14em;
   }
 
+  .badge.bias {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.9rem;
+    background: rgba(64, 217, 255, 0.12);
+    border-color: rgba(64, 217, 255, 0.32);
+    color: var(--accent);
+    text-transform: none;
+    letter-spacing: 0.12em;
+    box-shadow: 0 10px 26px rgba(64, 217, 255, 0.12);
+  }
+
+  .badge.bias .badge-bias__value {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.82;
+  }
+
+  .badge.bias .badge-bias__value::before {
+    content: '•';
+    margin-right: 0.35rem;
+    opacity: 0.65;
+  }
+
+  .badge.bias.left,
+  .badge.bias.left-soft {
+    color: var(--bias-left);
+    border-color: rgba(47, 107, 255, 0.45);
+    background: rgba(47, 107, 255, 0.18);
+    box-shadow: 0 10px 28px rgba(47, 107, 255, 0.22);
+  }
+
+  .badge.bias.center {
+    color: var(--bias-center);
+    border-color: rgba(155, 169, 200, 0.38);
+    background: rgba(155, 169, 200, 0.16);
+    box-shadow: 0 10px 28px rgba(155, 169, 200, 0.18);
+  }
+
+  .badge.bias.right,
+  .badge.bias.right-soft {
+    color: var(--bias-right);
+    border-color: rgba(255, 95, 95, 0.45);
+    background: rgba(255, 95, 95, 0.18);
+    box-shadow: 0 10px 28px rgba(255, 95, 95, 0.2);
+  }
+
   .badge.credibility {
     border-color: rgba(64, 217, 255, 0.35);
     background: rgba(64, 217, 255, 0.08);
@@ -1133,17 +1127,34 @@ CHANGELOG:
     letter-spacing: 0.18em;
   }
 
-  .bias-meter {
-    height: 18px;
-    border: none;
-    background: linear-gradient(90deg, rgba(47, 107, 255, 0.35), rgba(155, 169, 200, 0.45) 50%, rgba(255, 95, 95, 0.35));
-    position: relative;
-    border-radius: 999px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), inset 0 6px 12px rgba(0, 0, 0, 0.45);
+  .bias-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    align-items: flex-start;
   }
 
-  .bias-indicator {
-    transition: left 0.45s var(--ios-ease);
+  .bias-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.4rem;
+    width: 100%;
+  }
+
+  .bias-title {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .bias-description {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.55);
   }
 
   .reading-progress {
@@ -3175,11 +3186,6 @@ function formatBiasScore(score = 0) {
   return `${rounded > 0 ? '+' : ''}${rounded.toFixed(1)}`;
 }
 
-function biasScoreToPercent(score = 0) {
-  const normalized = ((score + BIAS_RANGE) / (BIAS_RANGE * 2)) * 100;
-  return Math.max(0, Math.min(100, normalized));
-}
-
 function analyzeBias(item) {
   const text = `${item.title || ''} ${item.desc || ''}`.toLowerCase();
   let score = SOURCE_BIAS_BASELINES.get(item.id) ?? 0;
@@ -3212,13 +3218,11 @@ function analyzeBias(item) {
   const bounded = Math.max(-BIAS_RANGE, Math.min(BIAS_RANGE, score));
   const descriptor = describeBias(bounded);
   const displayScore = Number(bounded.toFixed(2));
-  const percent = Math.min(98, Math.max(2, biasScoreToPercent(displayScore)));
 
   return {
     score: displayScore,
     label: descriptor.label,
-    className: descriptor.className,
-    percent
+    className: descriptor.className
   };
 }
 
@@ -3377,7 +3381,6 @@ async function loadFeeds() {
       item.biasScore = bias.score;
       item.biasLabel = bias.label;
       item.biasClass = bias.className;
-      item.biasPercent = bias.percent;
     });
 
     render();
@@ -3454,11 +3457,11 @@ function createCard(item, index = 0, total = 1) {
   const biasClass = item.biasClass || 'center';
   const biasScore = typeof item.biasScore === 'number' && !Number.isNaN(item.biasScore) ? item.biasScore : 0;
   const biasScoreFormatted = formatBiasScore(biasScore);
-  const biasPercent = Number.isFinite(item.biasPercent) ? item.biasPercent : 50;
-  const biasPosition = Math.max(2, Math.min(98, Math.round(biasPercent * 10) / 10));
+  const biasScoreSafe = escapeHTML(biasScoreFormatted);
   const biasLabelSafe = escapeHTML(biasLabel);
   const biasAriaText = `Political lean ${biasLabel} with score ${biasScoreFormatted}`;
   const biasAria = escapeHTML(biasAriaText);
+  const biasBadge = `<span class="badge bias ${biasClass}" aria-label="${biasAria}" title="${biasAria}"><span class="badge-bias__label" aria-hidden="true">${biasLabelSafe}</span><span class="badge-bias__value" aria-hidden="true">${biasScoreSafe}</span><span class="sr-only">${biasAria}</span></span>`;
 
   const credibilityBadge = `<span class="badge credibility${credibility.toneClass ? ` ${credibility.toneClass}` : ''}" title="${escapeHTML(credibility.description)}">${escapeHTML(credibility.label)}</span>`;
   const freshBadge = isFresh ? '<span class="badge badge-fresh">NEW</span>' : '';
@@ -3491,19 +3494,9 @@ function createCard(item, index = 0, total = 1) {
         <div class="bias-section" aria-label="${biasAria}">
           <div class="bias-header">
             <span class="bias-title">Political Lean</span>
-            <span class="bias-label ${biasClass}">${biasLabelSafe}</span>
+            ${biasBadge}
           </div>
-          <div class="bias-meter" role="img" aria-label="${biasAria}">
-            <div class="bias-indicator" style="left:${biasPosition}%;">
-              <span class="bias-score" aria-hidden="true">${biasScoreFormatted}</span>
-              <span class="bias-marker" aria-hidden="true"></span>
-            </div>
-            <span class="sr-only">${biasAria}</span>
-          </div>
-          <div class="bias-scale-labels" aria-hidden="true">
-            <span>LEFT</span>
-            <span>RIGHT</span>
-          </div>
+          <p class="bias-description">Normalized on a -10 (Left) to +10 (Right) scale.</p>
         </div>
         <div class="card-credibility" aria-label="Credibility insight ${escapeHTML(credibility.detail)}">
           <span class="card-credibility__label">Credibility</span>


### PR DESCRIPTION
## Summary
- refresh article card styling with a subtler glass gradient, updated grid header layout, and softer hover states
- replace the bias scale with a reusable badge that shows the lean label and score plus supporting description
- switch the live blip indicator to the theme blue and tweak small-screen bias layout

## Testing
- no tests run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9fb5351788326840b53589edc9f1a