### PR TITLE
Reduce card footprint and improve interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ CHANGELOG:
     --border-strong: rgba(124, 92, 255, 0.45);
     --shadow-soft: 0 30px 60px rgba(3, 6, 22, 0.55);
     --shadow-strong: 0 50px 80px rgba(5, 8, 28, 0.7);
-    --card-radius: 22px;
+    --card-radius: 18px;
     --tab-bar-height: 78px;
     --gutter: clamp(1rem, 1vw + 1rem, 2.5rem);
     --pull-distance: 0px;
@@ -365,7 +365,7 @@ CHANGELOG:
 
   .list {
     display: grid;
-    gap: clamp(0.95rem, 1.2vw, 1.35rem);
+    gap: clamp(0.7rem, 1vw, 1.1rem);
     margin: 0;
     padding: 0;
   }
@@ -442,20 +442,20 @@ CHANGELOG:
   }
 
   .card--lead .titleline {
-    font-size: 1.1rem;
+    font-size: 1rem;
   }
 
   .card--feature .titleline {
-    font-size: 1rem;
+    font-size: 0.94rem;
   }
 
   .card-head {
     position: relative;
     display: grid;
     grid-template-columns: auto 1fr auto auto;
-    gap: 0.95rem;
+    gap: 0.75rem;
     align-items: center;
-    padding: 1.1rem 1.35rem;
+    padding: 0.9rem 1.1rem;
     cursor: pointer;
   }
 
@@ -469,8 +469,8 @@ CHANGELOG:
   }
 
   .favicon {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     border-radius: 10px;
     background-color: rgba(255, 255, 255, 0.12);
     background-size: cover;
@@ -481,11 +481,11 @@ CHANGELOG:
 
   .titleline {
     font-family: 'Space Grotesk', 'Inter', sans-serif;
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     font-weight: 600;
     letter-spacing: 0.01em;
     color: var(--text);
-    margin-bottom: 0.3rem;
+    margin-bottom: 0.2rem;
     transition: color 0.35s ease;
   }
 
@@ -493,14 +493,14 @@ CHANGELOG:
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.4rem;
-    color: rgba(255, 255, 255, 0.65);
-    font-size: 0.74rem;
+    gap: 0.3rem;
+    color: rgba(255, 255, 255, 0.62);
+    font-size: 0.68rem;
   }
 
   .time {
     letter-spacing: 0.18em;
-    font-size: 0.68rem;
+    font-size: 0.64rem;
     text-transform: uppercase;
   }
 
@@ -512,10 +512,10 @@ CHANGELOG:
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.25rem 0.6rem;
+    padding: 0.2rem 0.5rem;
     border-radius: 999px;
     border: 1px solid rgba(124, 92, 255, 0.25);
-    font-size: 0.65rem;
+    font-size: 0.6rem;
     font-weight: 600;
     letter-spacing: 0.2em;
     text-transform: uppercase;
@@ -593,8 +593,8 @@ CHANGELOG:
   }
 
   .reading-progress {
-    width: 62px;
-    height: 6px;
+    width: 52px;
+    height: 5px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.08);
     overflow: hidden;
@@ -612,18 +612,21 @@ CHANGELOG:
   }
 
   .expand-btn {
+    appearance: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     font-family: 'Space Grotesk', 'Inter', sans-serif;
-    font-size: 0.8rem;
+    font-size: 0.72rem;
+    line-height: 1;
     color: var(--muted);
     border: 1px solid rgba(124, 92, 255, 0.22);
     border-radius: 999px;
-    padding: 0.3rem 0.55rem;
+    padding: 0.25rem 0.45rem;
     background: rgba(255, 255, 255, 0.03);
-    min-width: 64px;
+    min-width: 56px;
     white-space: nowrap;
+    cursor: pointer;
     transition: background 0.3s ease, color 0.3s ease;
   }
 
@@ -633,11 +636,11 @@ CHANGELOG:
   }
 
   .card-body {
-    padding: 1.05rem 1.5rem 1.35rem;
+    padding: 0.85rem 1.15rem 1.1rem;
     border-top: 1px solid rgba(255, 255, 255, 0.05);
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.85rem;
   }
 
   .card-body[hidden] {
@@ -646,15 +649,15 @@ CHANGELOG:
 
   .card-summary {
     color: rgba(236, 240, 255, 0.82);
-    font-size: 0.88rem;
+    font-size: 0.82rem;
   }
 
   .card-actions {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.9rem;
-    margin-top: 0.75rem;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
     flex-wrap: wrap;
   }
 
@@ -665,10 +668,10 @@ CHANGELOG:
     gap: 0.35rem;
     text-decoration: none;
     font-weight: 600;
-    font-size: 0.72rem;
-    letter-spacing: 0.25em;
+    font-size: 0.68rem;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
-    padding: 0.55rem 1.2rem;
+    padding: 0.45rem 1rem;
     border-radius: 999px;
     background: linear-gradient(135deg, var(--accent) 0%, var(--accent-soft) 100%);
     color: #030716;
@@ -994,17 +997,18 @@ CHANGELOG:
     font-size: 0.68rem;
     letter-spacing: 0.28em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--accent-soft);
   }
 
   .filter-sheet__source-value {
     font-size: 0.9rem;
     font-weight: 600;
+    color: var(--accent-strong);
   }
 
   .filter-sheet__source-hint {
     font-size: 0.7rem;
-    color: rgba(255, 255, 255, 0.55);
+    color: rgba(157, 165, 196, 0.85);
   }
 
   .source-sheet__panel {
@@ -1095,7 +1099,7 @@ CHANGELOG:
     font-size: 0.68rem;
     letter-spacing: 0.24em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(148, 182, 255, 0.68);
   }
 
   .source-option__bias {
@@ -1554,6 +1558,46 @@ function ensureReadProgress(cardId, minimum) {
   return setReadProgress(cardId, minimum);
 }
 
+function updateCardExpansionForElement(card, expanded) {
+  if (!card) {
+    return;
+  }
+
+  card.classList.toggle('open', Boolean(expanded));
+
+  const headerEl = card.querySelector('.card-head');
+  if (headerEl) {
+    headerEl.setAttribute('aria-expanded', String(Boolean(expanded)));
+  }
+
+  const bodyEl = card.querySelector('.card-body');
+  if (bodyEl) {
+    bodyEl.hidden = !expanded;
+  }
+
+  const expandBtnEl = card.querySelector('.expand-btn');
+  if (expandBtnEl) {
+    expandBtnEl.textContent = expanded ? 'Hide' : 'Open';
+  }
+
+  const cardId = card.dataset?.cardId;
+  if (cardId) {
+    if (expanded) {
+      STATE.expandedCards.add(cardId);
+    } else {
+      STATE.expandedCards.delete(cardId);
+    }
+  }
+}
+
+function collapseOpenCards(except) {
+  document.querySelectorAll('.card.open').forEach(card => {
+    if (!except || card !== except) {
+      updateCardExpansionForElement(card, false);
+    }
+  });
+}
+
 function isFreshStory(item) {
   const published = new Date(item.pubDate).getTime();
   if (!Number.isFinite(published)) {
@@ -1644,6 +1688,18 @@ function updatePullIndicator(state, text, hideDelay = 1400) {
   }
 }
 
+function scrollToTop() {
+  if (typeof window === 'undefined' || typeof window.scrollTo !== 'function') {
+    return;
+  }
+
+  try {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  } catch (error) {
+    window.scrollTo(0, 0);
+  }
+}
+
 function syncActiveNav() {
   const currentView = STATE.view;
   const filters = document.getElementById('filters');
@@ -1670,7 +1726,14 @@ function syncActiveNav() {
 }
 
 function changeView(view) {
-  if (!view || view === STATE.view) {
+  if (!view) {
+    syncActiveNav();
+    triggerHaptic('tap');
+    return;
+  }
+
+  if (view === STATE.view) {
+    scrollToTop();
     syncActiveNav();
     triggerHaptic('tap');
     return;
@@ -1680,6 +1743,7 @@ function changeView(view) {
     STATE.view = view;
     persistState();
     render();
+    scrollToTop();
   };
 
   if (document.startViewTransition) {
@@ -3165,7 +3229,7 @@ function createCard(item, index = 0, total = 1) {
       <div class="reading-progress" role="progressbar" aria-label="Reading progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progressValue)}">
         <span class="reading-progress__meter" style="--progress:${progressFraction.toFixed(2)};"></span>
       </div>
-      <div class="expand-btn" aria-hidden="true">${isExpanded ? 'Hide' : 'Open'}</div>
+      <button type="button" class="expand-btn" aria-hidden="true" tabindex="-1">${isExpanded ? 'Hide' : 'Open'}</button>
     </div>
     <div class="card-body" id="body-${cardId}" role="region">
       <div class="card-summary">${escapeHTML(item.desc || 'No summary available.')}</div>
@@ -3204,54 +3268,18 @@ function createCard(item, index = 0, total = 1) {
 
   applyProgress(progressValue);
 
-  const collapseCardElement = target => {
-    if (!target) {
-      return;
-    }
-
-    target.classList.remove('open');
-    const button = target === article ? expandBtn : target.querySelector('.expand-btn');
-    if (button) {
-      button.textContent = 'Open';
-    }
-
-    const targetHeader = target === article ? header : target.querySelector('.card-head');
-    if (targetHeader) {
-      targetHeader.setAttribute('aria-expanded', 'false');
-    }
-
-    const targetBody = target === article ? cardBody : target.querySelector('.card-body');
-    if (targetBody) {
-      targetBody.hidden = true;
-    }
-
-    if (target.dataset && target.dataset.cardId) {
-      STATE.expandedCards.delete(target.dataset.cardId);
-    }
-  };
-
   const openCard = () => {
-    document.querySelectorAll('.card.open').forEach(card => {
-      if (card !== article) {
-        collapseCardElement(card);
-      }
-    });
-
-    article.classList.add('open');
-    expandBtn.textContent = 'Hide';
-    header.setAttribute('aria-expanded', 'true');
-    if (cardBody) {
-      cardBody.hidden = false;
-    }
-
+    collapseOpenCards(article);
+    updateCardExpansionForElement(article, true);
     triggerHaptic('expand');
     const ensured = ensureReadProgress(cardId, 40);
     applyProgress(ensured);
-    STATE.expandedCards.add(cardId);
+    persistState();
   };
 
   const closeCard = () => {
-    collapseCardElement(article);
+    updateCardExpansionForElement(article, false);
+    persistState();
   };
 
   const toggleCard = () => {
@@ -3260,17 +3288,24 @@ function createCard(item, index = 0, total = 1) {
     } else {
       openCard();
     }
-
-    persistState();
   };
 
-  header.addEventListener('click', toggleCard);
-  header.addEventListener('keydown', event => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
+  if (header) {
+    header.addEventListener('click', toggleCard);
+    header.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleCard();
+      }
+    });
+  }
+
+  if (expandBtn) {
+    expandBtn.addEventListener('click', event => {
+      event.stopPropagation();
       toggleCard();
-    }
-  });
+    });
+  }
 
   if (articleLink) {
     articleLink.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- tighten card spacing, padding, and typography so feed items take up less space
- centralize the expansion logic so cards can reliably collapse and wire the expand control directly
- scroll back to the top on view changes and refresh the source filter colors to match the theme

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb308848908326bfe433f63f0d343d