### PR TITLE
Fix missing debounce helper for search input

### DIFF
--- a/index.html
+++ b/index.html
@@ -2217,6 +2217,17 @@
         return result;
       }
 
+      function debounce(callback, wait = 200) {
+        let timeoutId;
+        return function (...args) {
+          const context = this;
+          clearTimeout(timeoutId);
+          timeoutId = setTimeout(() => {
+            callback.apply(context, args);
+          }, wait);
+        };
+      }
+
       function clamp(value, min, max) {
         if (Number.isNaN(value)) return min;
         return Math.min(Math.max(value, min), max);


### PR DESCRIPTION
## Summary
- define a reusable debounce helper to delay search input handlers
- prevent the dashboard initialization from failing due to an undefined debounce reference

## Testing
- Manual verification with Playwright against `http://127.0.0.1:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68cc5227581c8326afc0cb93e74e220d