### PR TITLE
Build CFB winner predictor single-page app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,2596 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b1320">
+  <meta name="color-scheme" content="dark light">
+  <title>CFB Winner Predictor</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1320;
+      --bg-elevated: #162235;
+      --bg-modal: rgba(8, 13, 22, 0.92);
+      --fg: #f4f6fb;
+      --fg-muted: #a5b1c7;
+      --accent: #66e0ff;
+      --accent-strong: #0ce2b9;
+      --danger: #ff6b7a;
+      --card: rgba(21, 33, 55, 0.96);
+      --border: rgba(255, 255, 255, 0.08);
+      --shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+      --font-stack: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
 
+    @media (prefers-color-scheme: light) {
+      :root {
+        color-scheme: light;
+        --bg: #f3f6fd;
+        --bg-elevated: #ffffff;
+        --bg-modal: rgba(0, 10, 20, 0.4);
+        --fg: #1a2233;
+        --fg-muted: #5a6376;
+        --accent: #0066ff;
+        --accent-strong: #00997a;
+        --card: rgba(255, 255, 255, 0.96);
+        --border: rgba(0, 20, 60, 0.08);
+        --shadow: 0 18px 38px rgba(30, 50, 80, 0.1);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: var(--font-stack);
+      background: var(--bg);
+      color: var(--fg);
+      height: 100%;
+    }
+
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: stretch;
+    }
+
+    .app {
+      width: 100%;
+      max-width: 960px;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      background: var(--bg);
+    }
+
+    header.top-bar {
+      position: sticky;
+      top: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem 0.4rem 1rem;
+      background: linear-gradient(180deg, rgba(11, 19, 32, 0.95) 0%, rgba(11, 19, 32, 0.7) 100%);
+      backdrop-filter: blur(12px);
+      z-index: 5;
+      gap: 0.5rem;
+    }
+
+    .top-left {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-height: 44px;
+    }
+
+    .icon-btn {
+      width: 44px;
+      height: 44px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      color: var(--fg);
+      font-size: 1.15rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      touch-action: manipulation;
+    }
+
+    .icon-btn:active {
+      transform: translateY(1px);
+    }
+
+    .week-label {
+      font-weight: 600;
+      font-size: 1.05rem;
+      padding: 0.5rem 0.75rem;
+      background: var(--bg-elevated);
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+    }
+
+    .filter-bar {
+      display: flex;
+      gap: 0.75rem;
+      padding: 0.4rem 1rem 0.6rem 1rem;
+      flex-wrap: wrap;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .input-chip {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.8rem;
+      color: var(--fg-muted);
+      min-width: min(160px, 44vw);
+    }
+
+    .input-chip input,
+    .input-chip select {
+      appearance: none;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 0.55rem 0.75rem;
+      background: var(--bg-elevated);
+      color: var(--fg);
+      font-size: 1rem;
+      min-height: 44px;
+    }
+
+    .results {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      padding: 0.75rem 1rem 5.5rem 1rem;
+    }
+
+    .game-card {
+      background: var(--card);
+      border-radius: 20px;
+      border: 1px solid var(--border);
+      padding: 1rem;
+      display: grid;
+      gap: 0.75rem;
+      box-shadow: var(--shadow);
+    }
+
+    .game-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .teams {
+      display: grid;
+      gap: 0.35rem;
+    }
+
+    .teams strong {
+      font-size: 1.1rem;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      color: var(--fg-muted);
+      font-size: 0.85rem;
+    }
+
+    .prob-pill {
+      padding: 0.5rem 0.85rem;
+      border-radius: 999px;
+      background: rgba(102, 224, 255, 0.15);
+      color: var(--accent);
+      font-weight: 600;
+      min-height: 36px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .confidence-ring {
+      width: 64px;
+      height: 64px;
+      position: relative;
+    }
+
+    .confidence-ring::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: 50%;
+      background: conic-gradient(var(--accent-strong) calc(var(--percent, 0) * 1%), rgba(255, 255, 255, 0.08) 0%);
+    }
+
+    .confidence-ring span {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+
+    .edge-badge {
+      border-radius: 12px;
+      padding: 0.35rem 0.65rem;
+      background: rgba(12, 226, 185, 0.18);
+      color: var(--accent-strong);
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+
+    details.why {
+      border-top: 1px solid var(--border);
+      padding-top: 0.6rem;
+    }
+
+    details.why summary {
+      cursor: pointer;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      min-height: 36px;
+      color: var(--accent);
+    }
+
+    details.why summary::marker,
+    details.why summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .driver-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      margin-top: 0.5rem;
+    }
+
+    .driver-chip {
+      padding: 0.35rem 0.55rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      font-size: 0.8rem;
+    }
+
+    .drawer-text {
+      margin-top: 0.5rem;
+      color: var(--fg-muted);
+      font-size: 0.9rem;
+      line-height: 1.4;
+    }
+
+    .banner-region {
+      padding: 0 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .banner {
+      border-radius: 14px;
+      padding: 0.65rem 0.85rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.88rem;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid var(--border);
+    }
+
+    .banner.error {
+      background: rgba(255, 107, 122, 0.18);
+      border-color: rgba(255, 107, 122, 0.42);
+    }
+
+    .banner.warning {
+      background: rgba(255, 190, 92, 0.18);
+      border-color: rgba(255, 190, 92, 0.32);
+    }
+
+    .banner.success {
+      background: rgba(12, 226, 185, 0.12);
+      border-color: rgba(12, 226, 185, 0.32);
+    }
+
+    .action-bar {
+      position: sticky;
+      bottom: 0;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 0.5rem;
+      padding: 0.75rem 1rem env(safe-area-inset-bottom, 0.75rem);
+      background: linear-gradient(180deg, rgba(11, 19, 32, 0.2) 0%, rgba(11, 19, 32, 0.95) 50%, rgba(11, 19, 32, 1) 100%);
+      backdrop-filter: blur(16px);
+      border-top: 1px solid var(--border);
+      z-index: 6;
+    }
+
+    .action {
+      min-height: 48px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 1rem;
+      touch-action: manipulation;
+    }
+
+    .action.accent {
+      background: linear-gradient(135deg, rgba(102, 224, 255, 0.32), rgba(12, 226, 185, 0.44));
+      border: none;
+      color: #041019;
+    }
+
+    .action.danger {
+      background: rgba(255, 107, 122, 0.18);
+      color: #ffbac1;
+      border: 1px solid rgba(255, 107, 122, 0.4);
+    }
+
+    .action:disabled {
+      opacity: 0.5;
+    }
+
+    .modal {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: flex-end;
+      justify-content: center;
+      z-index: 20;
+      padding: env(safe-area-inset-top, 1.5rem) 1rem env(safe-area-inset-bottom, 1rem) 1rem;
+    }
+
+    .modal-content {
+      width: min(640px, 100%);
+      background: var(--bg-elevated);
+      border-radius: 24px 24px 16px 16px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      padding: 1.25rem 1.25rem 1rem 1.25rem;
+      max-height: 92vh;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .modal-header h2 {
+      margin: 0;
+      font-size: 1.4rem;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .field input[type="password"],
+    .field input[type="number"] {
+      background: var(--bg);
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      padding: 0.6rem 0.75rem;
+      color: var(--fg);
+      font-size: 1rem;
+      min-height: 44px;
+    }
+
+    .field .muted {
+      color: var(--fg-muted);
+      font-size: 0.85rem;
+    }
+
+    .field.toggles label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      min-height: 36px;
+    }
+
+    .manual-injury-list {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .manual-team {
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 0.75rem;
+      background: rgba(255, 255, 255, 0.04);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .manual-team h4 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .manual-team .position-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+      gap: 0.35rem;
+    }
+
+    .manual-team label {
+      font-size: 0.85rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 999px;
+      padding: 0.35rem 0.55rem;
+    }
+
+    .scrim {
+      position: fixed;
+      inset: 0;
+      background: rgba(4, 7, 12, 0.65);
+      backdrop-filter: blur(3px);
+      z-index: 10;
+    }
+
+    .toast-region {
+      position: fixed;
+      bottom: 6.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      display: grid;
+      gap: 0.5rem;
+      width: min(90vw, 420px);
+      z-index: 30;
+    }
+
+    .toast {
+      background: var(--bg-elevated);
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      padding: 0.75rem 1rem;
+      font-size: 0.95rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      box-shadow: var(--shadow);
+    }
+
+    .skeleton {
+      border-radius: 16px;
+      background: linear-gradient(90deg, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.12) 40%, rgba(255, 255, 255, 0.08) 80%);
+      background-size: 320% 100%;
+      min-height: 132px;
+      animation: shimmer 1.6s infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.001s !important;
+        transition-duration: 0.001s !important;
+      }
+    }
+
+    @keyframes shimmer {
+      0% {
+        background-position: 200% 0;
+      }
+      100% {
+        background-position: -200% 0;
+      }
+    }
+
+    @media (min-width: 720px) {
+      .action-bar {
+        grid-template-columns: repeat(4, minmax(120px, 1fr));
+      }
+
+      .results {
+        padding: 1rem 1.5rem 6rem 1.5rem;
+      }
+
+      header.top-bar {
+        padding: 1rem 1.5rem 0.6rem 1.5rem;
+      }
+
+      .filter-bar {
+        padding: 0.5rem 1.5rem 0.75rem 1.5rem;
+      }
+    }
+
+    button, select, input {
+      font-family: inherit;
+    }
+
+    button {
+      cursor: pointer;
+    }
+
+    button:focus-visible,
+    select:focus-visible,
+    input:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    .muted {
+      color: var(--fg-muted);
+    }
+
+    .small {
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="app" id="app">
+    <header class="top-bar">
+      <div class="top-left">
+        <button id="prevWeek" class="icon-btn" aria-label="Previous weekend" title="Previous weekend">‹</button>
+        <div class="week-label" id="weekLabel">Loading…</div>
+        <button id="nextWeek" class="icon-btn" aria-label="Next weekend" title="Next weekend">›</button>
+      </div>
+      <button id="settingsBtn" class="icon-btn" aria-haspopup="dialog" aria-expanded="false" title="Settings">⚙️</button>
+    </header>
+
+    <section class="filter-bar" aria-label="Filters">
+      <label class="input-chip">
+        <span>Team</span>
+        <input id="teamFilter" type="search" placeholder="Filter by team" autocomplete="off">
+      </label>
+      <label class="input-chip">
+        <span>Conference</span>
+        <select id="conferenceFilter">
+          <option value="">All</option>
+        </select>
+      </label>
+      <label class="input-chip">
+        <span>Sort</span>
+        <select id="sortSelect">
+          <option value="confidence">By confidence</option>
+          <option value="edge">By edge</option>
+          <option value="kickoff">By kickoff</option>
+        </select>
+      </label>
+    </section>
+
+    <section id="bannerRegion" class="banner-region" role="status" aria-live="polite"></section>
+
+    <main id="results" class="results" aria-live="polite" aria-busy="true"></main>
+
+    <footer class="action-bar" role="toolbar" aria-label="Actions">
+      <button id="refreshBtn" class="action" type="button">Refresh Data</button>
+      <button id="predictBtn" class="action accent" type="button">Predict</button>
+      <button id="exportBtn" class="action" type="button">Export JSON</button>
+      <button id="resetBtn" class="action danger" type="button">Reset</button>
+    </footer>
+
+    <div id="settingsModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>
+      <div class="modal-content">
+        <header class="modal-header">
+          <h2 id="settingsTitle">Settings</h2>
+          <button class="icon-btn" id="closeSettings" aria-label="Close settings">✕</button>
+        </header>
+        <form id="settingsForm">
+          <label class="field">
+            <span>Enter CFBD API key</span>
+            <input id="cfbdKeyInput" type="password" placeholder="Paste API key" autocomplete="off" inputmode="text">
+          </label>
+          <div class="field toggles">
+            <label><input type="checkbox" id="marketsToggle"> <span>Use betting markets (optional)</span></label>
+            <label><input type="checkbox" id="weatherToggle"> <span>Use weather forecasts</span></label>
+            <label><input type="checkbox" id="manualInjToggle"> <span>Manual injuries</span></label>
+            <label><input type="checkbox" id="demoToggle"> <span>Demo mode (offline sample)</span></label>
+          </div>
+          <label class="field">
+            <span>Timezone offset override (minutes, optional)</span>
+            <input id="tzOverrideInput" type="number" inputmode="numeric" placeholder="e.g. -300">
+          </label>
+          <div class="field manual-injuries" id="manualInjuryPanel" hidden>
+            <h3 style="margin:0;font-size:1.05rem;">Manual injuries</h3>
+            <p class="muted">Mark key absences per team. Applies when API data is unavailable.</p>
+            <div id="manualInjuryList" class="manual-injury-list" role="group" aria-label="Manual injuries"></div>
+          </div>
+          <menu class="modal-actions" style="display:flex;justify-content:space-between;gap:0.75rem;padding:0;margin:0;list-style:none;">
+            <button type="button" id="forgetKeyBtn" class="action danger">Forget keys</button>
+            <button type="submit" class="action accent">Save</button>
+          </menu>
+        </form>
+      </div>
+    </div>
+    <div id="scrim" class="scrim" hidden></div>
+    <div id="toastRegion" class="toast-region" aria-live="assertive" aria-atomic="true"></div>
+  </div>
+
+  <script>
+    (() => {
+      'use strict';
+
+      const STATE_VERSION = '2024.09.15';
+      const SETTINGS_KEY = 'cfbPredictor.settings.v1';
+      const CACHE_PREFIX = 'cfbPredictor.cache.';
+      const CALIBRATION_KEY = 'cfbPredictor.calibration.v1';
+      const WEATHER_CACHE_VERSION = '1';
+      const CFBD_BASE = 'https://api.collegefootballdata.com';
+      const OPEN_METEO_BASE = 'https://api.open-meteo.com/v1/forecast';
+      const DEFAULT_HOME_ADV = 55;
+      const MAX_TRAINING_GAMES = 2000;
+      const TEAM_POSITIONS = ['QB', 'WR1', 'RB1', 'LT', 'CB1', 'EDGE1', 'S', 'K'];
+      const INJURY_WEIGHTS = { QB: 4.0, WR1: 1.0, RB1: 0.6, LT: 0.8, CB1: 1.2, EDGE1: 1.2, S: 0.6, K: 0.3 };
+      const WEATHER_TTL = 1000 * 60 * 60 * 6;
+      const METRIC_TTL = 1000 * 60 * 60 * 24;
+      const LINES_TTL = 1000 * 60 * 60 * 2;
+      const SETTINGS_DEFAULT = {
+        cfbdKey: '',
+        useMarkets: true,
+        useWeather: true,
+        manualInjuries: false,
+        demoMode: false,
+        tzOffsetOverride: null,
+        manualInjuryOverrides: {},
+      };
+
+      const elements = {};
+      const state = {
+        initialized: false,
+        weekOffset: 0,
+        range: null,
+        settings: loadSettings(),
+        filters: { team: '', conference: '', sort: 'confidence' },
+        data: {
+          games: [],
+          teams: {},
+          venues: {},
+          metrics: {},
+          elo: {},
+          sp: {},
+          lines: [],
+          injuries: [],
+          weather: {},
+          calendar: [],
+          trainingGames: [],
+        },
+        predictions: [],
+        calibration: loadCalibration(),
+        banners: new Map(),
+        workerReady: false,
+      };
+
+      class TokenBucket {
+        constructor(ratePerSecond = 3, capacity = 3) {
+          this.rate = ratePerSecond;
+          this.capacity = capacity;
+          this.tokens = capacity;
+          this.queue = [];
+          setInterval(() => {
+            this.tokens = Math.min(this.capacity, this.tokens + this.rate);
+            this._drain();
+          }, 1000);
+        }
+        removeToken() {
+          return new Promise((resolve) => {
+            const tryTake = () => {
+              if (this.tokens > 0) {
+                this.tokens -= 1;
+                resolve();
+              } else {
+                this.queue.push(tryTake);
+              }
+            };
+            tryTake();
+          });
+        }
+        _drain() {
+          while (this.tokens > 0 && this.queue.length) {
+            const next = this.queue.shift();
+            if (typeof next === 'function') {
+              next();
+            }
+          }
+        }
+      }
+
+      const tokenBucket = new TokenBucket(3, 3);
+
+      function loadSettings() {
+        try {
+          const raw = localStorage.getItem(SETTINGS_KEY);
+          if (!raw) return { ...SETTINGS_DEFAULT };
+          const parsed = JSON.parse(raw);
+          return { ...SETTINGS_DEFAULT, ...parsed };
+        } catch (err) {
+          console.error('Failed to load settings', err);
+          return { ...SETTINGS_DEFAULT };
+        }
+      }
+
+      function persistSettings() {
+        try {
+          localStorage.setItem(SETTINGS_KEY, JSON.stringify(state.settings));
+        } catch (err) {
+          console.error('Failed to persist settings', err);
+          showToast('Unable to save settings locally', 'error');
+        }
+      }
+
+      function loadCalibration() {
+        try {
+          const raw = localStorage.getItem(CALIBRATION_KEY);
+          if (!raw) return null;
+          const parsed = JSON.parse(raw);
+          if (parsed?.version === STATE_VERSION) {
+            return parsed;
+          }
+          return null;
+        } catch (err) {
+          console.error('Failed to load calibration', err);
+          return null;
+        }
+      }
+
+      const Cache = {
+        get(key) {
+          try {
+            const raw = localStorage.getItem(CACHE_PREFIX + key);
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            if (!parsed || parsed.version !== STATE_VERSION) return null;
+            if (parsed.expiry && Date.now() > parsed.expiry) {
+              localStorage.removeItem(CACHE_PREFIX + key);
+              return null;
+            }
+            return parsed.value;
+          } catch (err) {
+            console.error('Cache read failed', key, err);
+            return null;
+          }
+        },
+        set(key, value, ttl) {
+          try {
+            const payload = { value, version: STATE_VERSION, expiry: ttl ? Date.now() + ttl : null };
+            localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(payload));
+          } catch (err) {
+            console.error('Cache write failed', key, err);
+          }
+        },
+        remove(key) {
+          try {
+            localStorage.removeItem(CACHE_PREFIX + key);
+          } catch (err) {
+            console.error('Cache remove failed', key, err);
+          }
+        },
+        keys() {
+          return Object.keys(localStorage).filter((k) => k.startsWith(CACHE_PREFIX));
+        },
+        clear() {
+          this.keys().forEach((k) => localStorage.removeItem(k));
+        }
+      };
+
+      function computeWeekendRange(offset = 0, baseDate = new Date()) {
+        const pivot = new Date(baseDate);
+        pivot.setDate(pivot.getDate() + offset * 7);
+        const day = pivot.getDay();
+        const diffToFriday = (5 - day + 7) % 7;
+        const friday = new Date(pivot);
+        friday.setDate(pivot.getDate() + diffToFriday);
+        const sunday = new Date(friday);
+        sunday.setDate(friday.getDate() + 2);
+        return { startDate: formatDate(friday), endDate: formatDate(sunday) };
+      }
+
+      function formatDate(date) {
+        const d = new Date(date);
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      }
+
+      function friendlyRange(range) {
+        const formatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+        const start = new Date(range.startDate + 'T00:00:00');
+        const end = new Date(range.endDate + 'T00:00:00');
+        return `${formatter.format(start)} – ${formatter.format(end)}`;
+      }
+
+      function setupElements() {
+        elements.weekLabel = document.getElementById('weekLabel');
+        elements.prevWeek = document.getElementById('prevWeek');
+        elements.nextWeek = document.getElementById('nextWeek');
+        elements.settingsBtn = document.getElementById('settingsBtn');
+        elements.results = document.getElementById('results');
+        elements.bannerRegion = document.getElementById('bannerRegion');
+        elements.refreshBtn = document.getElementById('refreshBtn');
+        elements.predictBtn = document.getElementById('predictBtn');
+        elements.exportBtn = document.getElementById('exportBtn');
+        elements.resetBtn = document.getElementById('resetBtn');
+        elements.settingsModal = document.getElementById('settingsModal');
+        elements.scrim = document.getElementById('scrim');
+        elements.settingsForm = document.getElementById('settingsForm');
+        elements.cfbdKeyInput = document.getElementById('cfbdKeyInput');
+        elements.marketsToggle = document.getElementById('marketsToggle');
+        elements.weatherToggle = document.getElementById('weatherToggle');
+        elements.manualInjToggle = document.getElementById('manualInjToggle');
+        elements.demoToggle = document.getElementById('demoToggle');
+        elements.tzOverrideInput = document.getElementById('tzOverrideInput');
+        elements.manualInjuryPanel = document.getElementById('manualInjuryPanel');
+        elements.manualInjuryList = document.getElementById('manualInjuryList');
+        elements.closeSettings = document.getElementById('closeSettings');
+        elements.teamFilter = document.getElementById('teamFilter');
+        elements.conferenceFilter = document.getElementById('conferenceFilter');
+        elements.sortSelect = document.getElementById('sortSelect');
+        elements.toastRegion = document.getElementById('toastRegion');
+        elements.forgetKeyBtn = document.getElementById('forgetKeyBtn');
+      }
+
+      function renderSkeleton(count = 3) {
+        elements.results.innerHTML = '';
+        elements.results.setAttribute('aria-busy', 'true');
+        for (let i = 0; i < count; i += 1) {
+          const skeleton = document.createElement('div');
+          skeleton.className = 'skeleton';
+          skeleton.setAttribute('aria-hidden', 'true');
+          elements.results.appendChild(skeleton);
+        }
+      }
+
+      function updateWeekLabel() {
+        if (!state.range) return;
+        elements.weekLabel.textContent = friendlyRange(state.range);
+      }
+      function showToast(message, level = 'info', timeout = 4000) {
+        const toast = document.createElement('div');
+        toast.className = 'toast';
+        toast.dataset.level = level;
+        toast.innerHTML = `<span>${message}</span>`;
+        elements.toastRegion.appendChild(toast);
+        setTimeout(() => {
+          toast.classList.add('hidden');
+          setTimeout(() => toast.remove(), 320);
+        }, timeout);
+      }
+
+      function showBanner(message, level = 'info', key) {
+        const bannerKey = key || `${level}-${Date.now()}`;
+        state.banners.set(bannerKey, { message, level, key: bannerKey });
+        renderBanners();
+        return bannerKey;
+      }
+
+      function dismissBanner(key) {
+        if (!key) return;
+        state.banners.delete(key);
+        renderBanners();
+      }
+
+      function renderBanners() {
+        elements.bannerRegion.innerHTML = '';
+        for (const banner of state.banners.values()) {
+          const div = document.createElement('div');
+          div.className = `banner ${banner.level}`;
+          div.textContent = banner.message;
+          elements.bannerRegion.appendChild(div);
+        }
+      }
+
+      function setupEvents() {
+        elements.prevWeek.addEventListener('click', () => {
+          state.weekOffset -= 1;
+          state.range = computeWeekendRange(state.weekOffset);
+          updateWeekLabel();
+          refreshSlate();
+        });
+        elements.nextWeek.addEventListener('click', () => {
+          state.weekOffset += 1;
+          state.range = computeWeekendRange(state.weekOffset);
+          updateWeekLabel();
+          refreshSlate();
+        });
+        elements.refreshBtn.addEventListener('click', () => refreshSlate({ force: true }));
+        elements.predictBtn.addEventListener('click', () => {
+          if (!state.data.games.length) {
+            showToast('Load games before predicting', 'warning');
+            return;
+          }
+          runPrediction();
+        });
+        elements.exportBtn.addEventListener('click', exportState);
+        elements.resetBtn.addEventListener('click', resetApp);
+        elements.settingsBtn.addEventListener('click', openSettings);
+        elements.closeSettings.addEventListener('click', closeSettings);
+        elements.scrim.addEventListener('click', closeSettings);
+        elements.settingsForm.addEventListener('submit', handleSettingsSubmit);
+        elements.forgetKeyBtn.addEventListener('click', () => {
+          state.settings.cfbdKey = '';
+          persistSettings();
+          elements.cfbdKeyInput.value = '';
+          showToast('CFBD key cleared from this device', 'success');
+        });
+        elements.teamFilter.addEventListener('input', () => {
+          state.filters.team = elements.teamFilter.value.trim();
+          renderGames();
+        });
+        elements.conferenceFilter.addEventListener('change', () => {
+          state.filters.conference = elements.conferenceFilter.value;
+          renderGames();
+        });
+        elements.sortSelect.addEventListener('change', () => {
+          state.filters.sort = elements.sortSelect.value;
+          renderGames();
+        });
+        elements.marketsToggle.addEventListener('change', () => {
+          state.settings.useMarkets = elements.marketsToggle.checked;
+          persistSettings();
+        });
+        elements.weatherToggle.addEventListener('change', () => {
+          state.settings.useWeather = elements.weatherToggle.checked;
+          persistSettings();
+        });
+        elements.manualInjToggle.addEventListener('change', () => {
+          const enabled = elements.manualInjToggle.checked;
+          state.settings.manualInjuries = enabled;
+          elements.manualInjuryPanel.hidden = !enabled;
+          persistSettings();
+          if (enabled) rebuildManualInjuryPanel();
+        });
+        elements.demoToggle.addEventListener('change', () => {
+          state.settings.demoMode = elements.demoToggle.checked;
+          persistSettings();
+          refreshSlate();
+        });
+      }
+
+      function openSettings() {
+        elements.settingsBtn.setAttribute('aria-expanded', 'true');
+        elements.settingsModal.hidden = false;
+        elements.scrim.hidden = false;
+        elements.cfbdKeyInput.value = state.settings.cfbdKey || '';
+        elements.marketsToggle.checked = state.settings.useMarkets;
+        elements.weatherToggle.checked = state.settings.useWeather;
+        elements.manualInjToggle.checked = state.settings.manualInjuries;
+        elements.demoToggle.checked = state.settings.demoMode;
+        elements.tzOverrideInput.value = state.settings.tzOffsetOverride ?? '';
+        if (state.settings.manualInjuries) {
+          elements.manualInjuryPanel.hidden = false;
+          rebuildManualInjuryPanel();
+        }
+      }
+
+      function closeSettings() {
+        elements.settingsBtn.setAttribute('aria-expanded', 'false');
+        elements.settingsModal.hidden = true;
+        elements.scrim.hidden = true;
+      }
+
+      function handleSettingsSubmit(evt) {
+        evt.preventDefault();
+        state.settings.cfbdKey = (elements.cfbdKeyInput.value || '').trim();
+        state.settings.useMarkets = elements.marketsToggle.checked;
+        state.settings.useWeather = elements.weatherToggle.checked;
+        state.settings.manualInjuries = elements.manualInjToggle.checked;
+        state.settings.demoMode = elements.demoToggle.checked;
+        const override = elements.tzOverrideInput.value === '' ? null : Number(elements.tzOverrideInput.value);
+        state.settings.tzOffsetOverride = Number.isFinite(override) ? override : null;
+        persistSettings();
+        closeSettings();
+        showToast('Settings updated', 'success');
+        if (state.settings.manualInjuries) rebuildManualInjuryPanel();
+      }
+
+      function rebuildManualInjuryPanel() {
+        const list = elements.manualInjuryList;
+        list.innerHTML = '';
+        const teams = new Set();
+        (state.data.games || []).forEach((game) => {
+          if (game.home_team) teams.add(game.home_team);
+          if (game.away_team) teams.add(game.away_team);
+        });
+        teams.forEach((team) => {
+          const overrides = state.settings.manualInjuryOverrides[team] || {};
+          const section = document.createElement('div');
+          section.className = 'manual-team';
+          const title = document.createElement('h4');
+          title.textContent = team;
+          section.appendChild(title);
+          const grid = document.createElement('div');
+          grid.className = 'position-grid';
+          TEAM_POSITIONS.forEach((pos) => {
+            const label = document.createElement('label');
+            const box = document.createElement('input');
+            box.type = 'checkbox';
+            box.checked = Boolean(overrides[pos]);
+            box.addEventListener('change', () => {
+              const target = state.settings.manualInjuryOverrides[team] || {};
+              target[pos] = box.checked;
+              state.settings.manualInjuryOverrides[team] = target;
+              persistSettings();
+            });
+            const span = document.createElement('span');
+            span.textContent = `${pos} out`;
+            label.appendChild(box);
+            label.appendChild(span);
+            grid.appendChild(label);
+          });
+          section.appendChild(grid);
+          list.appendChild(section);
+        });
+        if (!teams.size) {
+          const empty = document.createElement('p');
+          empty.className = 'muted small';
+          empty.textContent = 'Load a slate to manage manual injuries.';
+          list.appendChild(empty);
+        } else {
+          const reminder = document.createElement('p');
+          reminder.className = 'muted small';
+          reminder.textContent = 'Selections persist on this device only.';
+          list.appendChild(reminder);
+        }
+      }
+
+      function resetApp() {
+        Cache.clear();
+        state.predictions = [];
+        state.data = {
+          games: [],
+          teams: {},
+          venues: {},
+          metrics: {},
+          elo: {},
+          sp: {},
+          lines: [],
+          injuries: [],
+          weather: {},
+          calendar: [],
+          trainingGames: [],
+        };
+        renderSkeleton();
+        showToast('Local caches cleared', 'success');
+      }
+
+      function exportState() {
+        const payload = {
+          exportedAt: new Date().toISOString(),
+          settings: state.settings,
+          calibration: state.calibration,
+          games: state.data.games,
+          predictions: state.predictions,
+          caches: Cache.keys().reduce((acc, fullKey) => {
+            const key = fullKey.replace(CACHE_PREFIX, '');
+            acc[key] = Cache.get(key);
+            return acc;
+          }, {}),
+        };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `cfb-predictor-${Date.now()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        a.remove();
+        showToast('Export ready', 'success');
+      }
+      async function refreshSlate({ force = false } = {}) {
+        state.banners.clear();
+        renderBanners();
+        renderSkeleton(4);
+        if (!state.range) state.range = computeWeekendRange(state.weekOffset);
+        updateWeekLabel();
+        if (state.settings.demoMode) {
+          await loadDemoData();
+          return;
+        }
+        try {
+          const data = await loadSlateData({ force });
+          state.data = { ...state.data, ...data };
+          populateConferenceFilter();
+          renderGames();
+          if (state.settings.manualInjuries) rebuildManualInjuryPanel();
+          showToast(`Loaded ${state.data.games.length} games`, 'success');
+        } catch (err) {
+          console.error('Refresh failed', err);
+          showBanner(`Unable to load slate: ${err.message || err}`, 'error', 'refresh');
+          elements.results.innerHTML = '<p class="muted">Unable to load games. Add your CFBD key or enable demo mode.</p>';
+          elements.results.setAttribute('aria-busy', 'false');
+        }
+      }
+
+      function populateConferenceFilter() {
+        const select = elements.conferenceFilter;
+        const prev = select.value;
+        select.innerHTML = '<option value="">All</option>';
+        const conferences = Array.from(new Set((state.data.games || []).flatMap((game) => [game.home_conference, game.away_conference]).filter(Boolean))).sort();
+        conferences.forEach((conf) => {
+          const option = document.createElement('option');
+          option.value = conf;
+          option.textContent = conf;
+          select.appendChild(option);
+        });
+        if (prev && conferences.includes(prev)) {
+          select.value = prev;
+          state.filters.conference = prev;
+        } else {
+          select.value = '';
+          state.filters.conference = '';
+        }
+      }
+
+      async function loadSlateData({ force = false } = {}) {
+        const { startDate, endDate } = state.range;
+        const season = determineSeasonYear(startDate);
+        const cacheKey = `slate_${season}_${startDate}_${endDate}`;
+        if (!force) {
+          const cached = Cache.get(cacheKey);
+          if (cached) {
+            elements.results.setAttribute('aria-busy', 'false');
+            return cached;
+          }
+        }
+        const [games, venues, calendar] = await Promise.all([
+          fetchGames({ season, startDate, endDate }),
+          fetchVenues({ season }),
+          fetchCalendar(season),
+        ]);
+        const futureGames = games.filter((game) => !game.completed);
+        const teamNames = new Set();
+        futureGames.forEach((game) => {
+          if (game.home_team) teamNames.add(game.home_team);
+          if (game.away_team) teamNames.add(game.away_team);
+        });
+        const teams = await fetchTeams(season);
+        const weeks = Array.from(new Set(futureGames.map((game) => game.week || inferWeekFromCalendar(game.start_date, calendar)).filter(Number.isFinite)));
+        const metrics = await ensureMetricSnapshots(season, weeks, 'regular');
+        const prevMetrics = await ensureMetricSnapshots(season - 1, [0], 'regular');
+        const elo = await ensureEloSnapshots(season, weeks, 'regular');
+        const prevElo = await ensureEloSnapshots(season - 1, [0], 'regular');
+        const sp = await ensureSPSnapshots(season, weeks, 'regular');
+        const lines = state.settings.useMarkets ? await fetchLines({ season, startDate, endDate }) : [];
+        const injuries = await fetchInjuries({ season, weeks });
+        const weather = state.settings.useWeather ? await fetchWeatherForGames(futureGames, venues) : {};
+        const trainingGames = await fetchTrainingGames({ season, cutoff: startDate });
+        const payload = {
+          games: futureGames,
+          teams,
+          venues,
+          metrics: { ...prevMetrics, ...metrics },
+          elo: { ...prevElo, ...elo },
+          sp,
+          lines,
+          injuries,
+          weather,
+          calendar,
+          trainingGames,
+        };
+        Cache.set(cacheKey, payload, 1000 * 60 * 30);
+        return payload;
+      }
+
+      function determineSeasonYear(dateString) {
+        const date = new Date(dateString + 'T00:00:00Z');
+        const year = date.getUTCFullYear();
+        const month = date.getUTCMonth() + 1;
+        return month < 2 ? year - 1 : year;
+      }
+
+      async function fetchGames({ season, startDate, endDate }) {
+        const params = new URLSearchParams({
+          year: String(season),
+          seasonType: 'regular',
+          division: 'fbs',
+          start: startDate,
+          end: endDate,
+        });
+        return cfbdRequest('/games', params, { ttl: 1000 * 60 * 15 });
+      }
+
+      async function fetchVenues({ season }) {
+        const key = `venues_${season}`;
+        const cached = Cache.get(key);
+        if (cached) return cached;
+        const params = new URLSearchParams({ year: String(season) });
+        const data = await cfbdRequest('/venues', params, { ttl: METRIC_TTL });
+        const map = {};
+        data.forEach((venue) => {
+          if (venue.id != null) map[venue.id] = venue;
+        });
+        Cache.set(key, map, METRIC_TTL);
+        return map;
+      }
+
+      async function fetchTeams(season) {
+        const key = `teams_${season}`;
+        const cached = Cache.get(key);
+        if (cached) return cached;
+        const params = new URLSearchParams({ year: String(season) });
+        const data = await cfbdRequest('/teams', params, { ttl: METRIC_TTL });
+        const map = {};
+        data.forEach((team) => {
+          if (team.school) map[team.school] = team;
+        });
+        Cache.set(key, map, METRIC_TTL);
+        return map;
+      }
+
+      async function fetchLines({ season, startDate, endDate }) {
+        const key = `lines_${season}_${startDate}_${endDate}`;
+        const cached = Cache.get(key);
+        if (cached) return cached;
+        const params = new URLSearchParams({ year: String(season), seasonType: 'regular', start: startDate, end: endDate });
+        try {
+          const data = await cfbdRequest('/lines', params, { ttl: LINES_TTL });
+          Cache.set(key, data, LINES_TTL);
+          return data;
+        } catch (err) {
+          showBanner('Lines not available: edge hidden', 'warning', 'lines');
+          return [];
+        }
+      }
+
+      async function fetchCalendar(season) {
+        const key = `calendar_${season}`;
+        const cached = Cache.get(key);
+        if (cached) return cached;
+        const params = new URLSearchParams({ year: String(season) });
+        const data = await cfbdRequest('/calendar', params, { ttl: METRIC_TTL });
+        Cache.set(key, data, METRIC_TTL);
+        return data;
+      }
+
+      async function fetchInjuries({ season, weeks }) {
+        const all = [];
+        const uniqueWeeks = Array.from(new Set(weeks.filter((w) => Number.isFinite(w))));
+        if (!uniqueWeeks.length) return all;
+        for (const week of uniqueWeeks) {
+          const params = new URLSearchParams({ year: String(season), week: String(week) });
+          try {
+            const data = await cfbdRequest('/injuries', params, { ttl: 1000 * 60 * 30 });
+            all.push(...data);
+          } catch (err) {
+            if (err.status === 404) {
+              showBanner('Injury endpoint unavailable: using manual toggles', 'warning', 'injuries');
+              break;
+            }
+            console.error('Injury fetch failed', err);
+          }
+        }
+        return all;
+      }
+
+      async function ensureMetricSnapshots(season, weeks, seasonType) {
+        const result = {};
+        const requestWeeks = weeks.length ? weeks : [0];
+        for (const week of requestWeeks) {
+          const key = `metrics_${season}_${seasonType}_${week}`;
+          let snapshot = Cache.get(key);
+          if (!snapshot) {
+            const params = new URLSearchParams({ year: String(season), seasonType });
+            if (week > 0) params.set('week', String(week));
+            try {
+              const raw = await cfbdRequest('/metrics/ppa/teams', params, { ttl: METRIC_TTL });
+              snapshot = compressPPAMetrics(raw);
+              Cache.set(key, snapshot, METRIC_TTL);
+            } catch (err) {
+              showBanner(`PPA metrics unavailable for week ${week}`, 'warning', `ppa_${season}_${week}`);
+              snapshot = {};
+            }
+          }
+          result[key] = snapshot;
+        }
+        return result;
+      }
+
+      async function ensureEloSnapshots(season, weeks, seasonType) {
+        const result = {};
+        const requestWeeks = weeks.length ? weeks : [0];
+        for (const week of requestWeeks) {
+          const key = `elo_${season}_${seasonType}_${week}`;
+          let snapshot = Cache.get(key);
+          if (!snapshot) {
+            const params = new URLSearchParams({ year: String(season), seasonType });
+            if (week > 0) params.set('week', String(week));
+            try {
+              const raw = await cfbdRequest('/metrics/elo', params, { ttl: METRIC_TTL });
+              snapshot = compressEloMetrics(raw);
+              Cache.set(key, snapshot, METRIC_TTL);
+            } catch (err) {
+              showBanner(`Elo metrics unavailable for week ${week}`, 'warning', `elo_${season}_${week}`);
+              snapshot = {};
+            }
+          }
+          result[key] = snapshot;
+        }
+        return result;
+      }
+
+      async function ensureSPSnapshots(season, weeks, seasonType) {
+        const result = {};
+        const requestWeeks = weeks.length ? weeks : [0];
+        for (const week of requestWeeks) {
+          const key = `sp_${season}_${seasonType}_${week}`;
+          let snapshot = Cache.get(key);
+          if (!snapshot) {
+            const params = new URLSearchParams({ year: String(season), seasonType });
+            if (week > 0) params.set('week', String(week));
+            try {
+              const raw = await cfbdRequest('/metrics/sp', params, { ttl: METRIC_TTL });
+              snapshot = compressSPMetrics(raw);
+              Cache.set(key, snapshot, METRIC_TTL);
+            } catch (err) {
+              snapshot = {};
+            }
+          }
+          result[key] = snapshot;
+        }
+        return result;
+      }
+
+      function compressPPAMetrics(entries) {
+        const map = {};
+        entries.forEach((row) => {
+          const team = row.team;
+          if (!team) return;
+          const offense = row.offense?.overall || {};
+          const defense = row.defense?.overall || {};
+          map[team] = {
+            offense: {
+              ppa: offense.ppa ?? 0,
+              successRate: offense.successRate ?? 0,
+              explosiveness: offense.explosiveness ?? 0,
+              passing: row.offense?.passing?.ppa ?? 0,
+              rushing: row.offense?.rushing?.ppa ?? 0,
+            },
+            defense: {
+              ppa: defense.ppa ?? 0,
+              successRate: defense.successRate ?? 0,
+              explosiveness: defense.explosiveness ?? 0,
+              passing: row.defense?.passing?.ppa ?? 0,
+              rushing: row.defense?.rushing?.ppa ?? 0,
+            },
+          };
+        });
+        return map;
+      }
+
+      function compressEloMetrics(entries) {
+        const map = {};
+        entries.forEach((row) => {
+          if (!row.team) return;
+          map[row.team] = {
+            elo: row.elo ?? row.rating ?? 1500,
+            offense: row.offense ?? 0,
+            defense: row.defense ?? 0,
+            special: row.specialTeams ?? 0,
+          };
+        });
+        return map;
+      }
+
+      function compressSPMetrics(entries) {
+        const map = {};
+        entries.forEach((row) => {
+          if (!row.team) return;
+          map[row.team] = {
+            rating: row.rating ?? 0,
+            offense: row.offense?.rating ?? 0,
+            defense: row.defense?.rating ?? 0,
+            special: row.specialTeams?.rating ?? 0,
+          };
+        });
+        return map;
+      }
+
+      async function fetchWeatherForGames(games, venues) {
+        const weather = {};
+        for (const game of games) {
+          if (!game.start_date) continue;
+          const venue = venues?.[game.venue_id];
+          let lat = venue?.latitude;
+          let lon = venue?.longitude;
+          if (lat == null || lon == null) {
+            const fallback = fallbackStadium(game.home_team);
+            lat = fallback.latitude;
+            lon = fallback.longitude;
+          }
+          if (lat == null || lon == null) continue;
+          const key = `${Number(lat).toFixed(3)}_${Number(lon).toFixed(3)}_${game.start_date}`;
+          let cached = Cache.get(`weather_${WEATHER_CACHE_VERSION}_${key}`);
+          if (!cached || Date.now() - cached.fetchedAt > WEATHER_TTL) {
+            try {
+              const forecast = await fetchOpenMeteo(lat, lon, game.start_date);
+              cached = { ...forecast, fetchedAt: Date.now() };
+              Cache.set(`weather_${WEATHER_CACHE_VERSION}_${key}`, cached, WEATHER_TTL);
+            } catch (err) {
+              showBanner('Weather unavailable: using neutral conditions', 'warning', `weather_${key}`);
+              continue;
+            }
+          }
+          weather[game.id || key] = cached;
+        }
+        return weather;
+      }
+
+      function fallbackStadium(team) {
+        const lookup = {
+          'Notre Dame': { latitude: 41.6986, longitude: -86.2353 },
+          'Army': { latitude: 41.387, longitude: -73.964 },
+          'Navy': { latitude: 38.985, longitude: -76.506 },
+          'Air Force': { latitude: 38.996, longitude: -104.843 },
+          'UConn': { latitude: 41.807, longitude: -72.251 },
+        };
+        return lookup[team] || {};
+      }
+
+      async function fetchOpenMeteo(lat, lon, kickoffIso) {
+        const start = kickoffIso.slice(0, 10);
+        const endDate = new Date(kickoffIso);
+        endDate.setHours(endDate.getHours() + 6);
+        const end = formatDate(endDate);
+        const url = `${OPEN_METEO_BASE}?latitude=${encodeURIComponent(lat)}&longitude=${encodeURIComponent(lon)}&hourly=temperature_2m,precipitation,wind_speed_10m,wind_gusts_10m,precipitation_probability&timezone=auto&start_date=${start}&end_date=${end}`;
+        const res = await fetch(url, { mode: 'cors' });
+        if (!res.ok) throw new Error(`Weather fetch failed (${res.status})`);
+        const data = await res.json();
+        const hours = data.hourly?.time || [];
+        if (!hours.length) throw new Error('Weather response missing hourly data');
+        const kickoffTime = new Date(kickoffIso).getTime();
+        let bestIndex = 0;
+        let minDiff = Infinity;
+        hours.forEach((iso, idx) => {
+          const diff = Math.abs(new Date(iso).getTime() - kickoffTime);
+          if (diff < minDiff) {
+            minDiff = diff;
+            bestIndex = idx;
+          }
+        });
+        return {
+          temperature: data.hourly?.temperature_2m?.[bestIndex] ?? null,
+          precipitation: data.hourly?.precipitation?.[bestIndex] ?? null,
+          precipitation_probability: data.hourly?.precipitation_probability?.[bestIndex] ?? null,
+          wind: data.hourly?.wind_speed_10m?.[bestIndex] ?? null,
+          gust: data.hourly?.wind_gusts_10m?.[bestIndex] ?? null,
+        };
+      }
+      async function cfbdRequest(path, params, { ttl } = {}) {
+        const url = `${CFBD_BASE}${path}?${params.toString()}`;
+        const headers = { Accept: 'application/json' };
+        if (state.settings.cfbdKey) {
+          headers.Authorization = `Bearer ${state.settings.cfbdKey}`;
+        }
+        const cacheKey = `${path}?${params.toString()}`;
+        if (ttl) {
+          const cached = Cache.get(cacheKey);
+          if (cached) return cached;
+        }
+        let attempt = 0;
+        while (attempt < 4) {
+          try {
+            await tokenBucket.removeToken();
+            const res = await fetch(url, { headers });
+            if (res.status === 401) {
+              const error = new Error('CFBD 401: Invalid key');
+              error.status = 401;
+              throw error;
+            }
+            if (res.status === 403) {
+              const error = new Error('CFBD 403: Forbidden');
+              error.status = 403;
+              throw error;
+            }
+            if (res.status === 429) {
+              showBanner('429: Rate limit, retrying…', 'warning', 'rate');
+              await delay(750 * (attempt + 1));
+              attempt += 1;
+              continue;
+            }
+            if (!res.ok) {
+              const error = new Error(`CFBD ${res.status}`);
+              error.status = res.status;
+              throw error;
+            }
+            const data = await res.json();
+            if (ttl) Cache.set(cacheKey, data, ttl);
+            return data;
+          } catch (err) {
+            if (err.status === 401) {
+              showBanner('CFBD 401: Invalid key', 'error', 'auth');
+              throw err;
+            }
+            if (attempt >= 3) throw err;
+            await delay(250 * Math.pow(2, attempt));
+            attempt += 1;
+          }
+        }
+        throw new Error('CFBD request failed');
+      }
+
+      function delay(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+
+      function inferWeekFromCalendar(dateString, calendar) {
+        const target = new Date(dateString);
+        let weekNumber = null;
+        (calendar || []).forEach((entry) => {
+          const start = entry.firstGameStart ?? entry.startDate ?? entry.firstGameStartDate;
+          const end = entry.lastGameStart ?? entry.endDate ?? entry.lastGameStartDate;
+          if (!start || !end) return;
+          const startDate = new Date(start);
+          const endDate = new Date(end);
+          if (target >= startDate && target <= endDate) {
+            weekNumber = entry.week ?? entry.weekNumber ?? weekNumber;
+          }
+        });
+        return weekNumber;
+      }
+
+      async function fetchTrainingGames({ season, cutoff }) {
+        const years = [season, season - 1];
+        const all = [];
+        for (const year of years) {
+          const params = new URLSearchParams({ year: String(year), seasonType: 'regular', division: 'fbs' });
+          try {
+            const games = await cfbdRequest('/games', params, { ttl: 1000 * 60 * 30 });
+            games.forEach((game) => {
+              if (!game.completed) return;
+              if (game.start_date && game.start_date >= cutoff) return;
+              all.push({ ...game, season: year });
+            });
+          } catch (err) {
+            console.error('Training games fetch failed', err);
+          }
+        }
+        all.sort((a, b) => new Date(a.start_date) - new Date(b.start_date));
+        return all.slice(-MAX_TRAINING_GAMES);
+      }
+
+      function renderGames() {
+        elements.results.innerHTML = '';
+        elements.results.setAttribute('aria-busy', 'false');
+        const games = state.data.games || [];
+        if (!games.length) {
+          const p = document.createElement('p');
+          p.className = 'muted';
+          p.textContent = 'No games available for this window. Try another week or Demo mode.';
+          elements.results.appendChild(p);
+          return;
+        }
+        let dataset = games.map((game) => ({
+          game,
+          prediction: state.predictions.find((item) => item.gameId === game.id),
+        }));
+        if (state.filters.team) {
+          const query = state.filters.team.toLowerCase();
+          dataset = dataset.filter(({ game }) => [game.home_team, game.away_team].some((team) => team?.toLowerCase().includes(query)));
+        }
+        if (state.filters.conference) {
+          dataset = dataset.filter(({ game }) => game.home_conference === state.filters.conference || game.away_conference === state.filters.conference);
+        }
+        dataset = sortCards(dataset, state.filters.sort);
+        dataset.forEach(({ game, prediction }) => {
+          const card = buildGameCard(game, prediction);
+          elements.results.appendChild(card);
+        });
+      }
+
+      function sortCards(cards, sortKey) {
+        switch (sortKey) {
+          case 'edge':
+            return cards.sort((a, b) => (b.prediction?.edge ?? 0) - (a.prediction?.edge ?? 0));
+          case 'kickoff':
+            return cards.sort((a, b) => new Date(a.game.start_date) - new Date(b.game.start_date));
+          case 'confidence':
+          default:
+            return cards.sort((a, b) => (b.prediction?.confidence ?? 0) - (a.prediction?.confidence ?? 0));
+        }
+      }
+
+      function buildGameCard(game, prediction) {
+        const card = document.createElement('article');
+        card.className = 'game-card';
+        const header = document.createElement('header');
+        const teams = document.createElement('div');
+        teams.className = 'teams';
+        const title = document.createElement('strong');
+        title.textContent = `${game.away_team} @ ${game.home_team}`;
+        teams.appendChild(title);
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.appendChild(document.createTextNode(formatKickoff(game)));
+        if (game.venue) {
+          const span = document.createElement('span');
+          span.textContent = game.venue + (game.neutral_site ? ' · Neutral' : '');
+          meta.appendChild(document.createTextNode(' · '));
+          meta.appendChild(span);
+        }
+        teams.appendChild(meta);
+        header.appendChild(teams);
+        if (prediction) {
+          const pill = document.createElement('div');
+          pill.className = 'prob-pill';
+          pill.textContent = `${prediction.homeTeam} ${Math.round(prediction.pHome * 100)}%`;
+          header.appendChild(pill);
+          const ring = document.createElement('div');
+          ring.className = 'confidence-ring';
+          ring.style.setProperty('--percent', Math.round(prediction.confidence * 100));
+          const span = document.createElement('span');
+          span.textContent = `${Math.round(prediction.confidence * 100)}%`;
+          ring.appendChild(span);
+          header.appendChild(ring);
+        }
+        card.appendChild(header);
+        if (prediction) {
+          const edgeRow = document.createElement('div');
+          edgeRow.className = 'meta';
+          edgeRow.innerHTML = `<span>Spread equiv: ${prediction.spreadEquiv}</span><span>Uncertainty: ${(prediction.band[0] * 100).toFixed(0)}%–${(prediction.band[1] * 100).toFixed(0)}%</span>`;
+          card.appendChild(edgeRow);
+          if (prediction.edge != null && state.settings.useMarkets) {
+            const badge = document.createElement('div');
+            badge.className = 'edge-badge';
+            badge.textContent = `Edge: ${prediction.edge > 0 ? '+' : ''}${(prediction.edge * 100).toFixed(1)}%`;
+            card.appendChild(badge);
+          }
+        }
+        const details = document.createElement('details');
+        details.className = 'why';
+        const summary = document.createElement('summary');
+        summary.textContent = 'Why';
+        details.appendChild(summary);
+        const drivers = document.createElement('div');
+        drivers.className = 'driver-chips';
+        (prediction?.drivers || ['Awaiting model']).slice(0, 4).forEach((driver) => {
+          const chip = document.createElement('span');
+          chip.className = 'driver-chip';
+          chip.textContent = driver;
+          drivers.appendChild(chip);
+        });
+        details.appendChild(drivers);
+        if (prediction?.rationale) {
+          const p = document.createElement('p');
+          p.className = 'drawer-text';
+          p.textContent = prediction.rationale;
+          details.appendChild(p);
+        }
+        card.appendChild(details);
+        return card;
+      }
+
+      function formatKickoff(game) {
+        if (!game.start_date) return 'TBD';
+        const date = new Date(game.start_date);
+        if (Number.isFinite(state.settings.tzOffsetOverride)) {
+          const tzMinutes = state.settings.tzOffsetOverride;
+          const local = new Date(date.getTime() + tzMinutes * 60000);
+          return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }).format(local);
+        }
+        return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }).format(date);
+      }
+      const FEATURE_NAMES = [
+        'deltaR',
+        'offPpaDiff',
+        'defPpaDiff',
+        'tempoDelta',
+        'homeFlag',
+        'neutralFlag',
+        'weatherWind',
+        'weatherPrecip',
+        'availability',
+        'marketSpread',
+        'recentForm',
+        'spRating',
+        'specialTeams',
+        'passMismatch'
+      ];
+      function lookupStoreValue(store, prefix, season, week, team, seasonType = 'regular') {
+        for (let w = Math.max(week, 0); w >= 0; w -= 1) {
+          const key = `${prefix}_${season}_${seasonType}_${w}`;
+          const snapshot = store[key];
+          if (snapshot && snapshot[team]) return snapshot[team];
+        }
+        const prevKey = `${prefix}_${season - 1}_${seasonType}_0`;
+        if (store[prevKey] && store[prevKey][team]) return store[prevKey][team];
+        return null;
+      }
+
+      function getTeamMetrics(team, season, week, seasonType = 'regular') {
+        const current = lookupStoreValue(state.data.metrics, 'metrics', season, week, team, seasonType);
+        const previous = lookupStoreValue(state.data.metrics, 'metrics', season - 1, 0, team, seasonType);
+        return blendMetrics(current, previous, week);
+      }
+
+      function getTeamElo(team, season, week, seasonType = 'regular') {
+        const snapshot = lookupStoreValue(state.data.elo, 'elo', season, week, team, seasonType);
+        const previous = lookupStoreValue(state.data.elo, 'elo', season - 1, 0, team, seasonType);
+        return snapshot?.elo ?? previous?.elo ?? 1500;
+      }
+
+      function getTeamSP(team, season, week, seasonType = 'regular') {
+        const snapshot = lookupStoreValue(state.data.sp, 'sp', season, week, team, seasonType);
+        const previous = lookupStoreValue(state.data.sp, 'sp', season - 1, 0, team, seasonType);
+        return snapshot || previous || { rating: 0, offense: 0, defense: 0, special: 0 };
+      }
+
+      function blendMetrics(current, previous, week) {
+        const lambda = 0.7;
+        const carries = previous || { offense: {}, defense: {} };
+        const curr = current || carries;
+        const scale = 1 - Math.pow(lambda, Math.max(1, week || 1));
+        function mix(field) {
+          const prevVal = carries[field] ?? 0;
+          const currVal = curr[field] ?? prevVal;
+          return scale * currVal + 0.3 * prevVal;
+        }
+        return {
+          offense: {
+            ppa: mix.call({ field: 'offense' }, 'ppa') ?? curr.offense?.ppa ?? 0,
+            successRate: mixValue(curr.offense?.successRate, carries.offense?.successRate, scale),
+            explosiveness: mixValue(curr.offense?.explosiveness, carries.offense?.explosiveness, scale),
+            passing: mixValue(curr.offense?.passing, carries.offense?.passing, scale),
+            rushing: mixValue(curr.offense?.rushing, carries.offense?.rushing, scale),
+          },
+          defense: {
+            ppa: mix.call({ field: 'defense' }, 'ppa') ?? curr.defense?.ppa ?? 0,
+            successRate: mixValue(curr.defense?.successRate, carries.defense?.successRate, scale),
+            explosiveness: mixValue(curr.defense?.explosiveness, carries.defense?.explosiveness, scale),
+            passing: mixValue(curr.defense?.passing, carries.defense?.passing, scale),
+            rushing: mixValue(curr.defense?.rushing, carries.defense?.rushing, scale),
+          },
+        };
+      }
+
+      function mixValue(current, previous, scale) {
+        const currVal = current ?? previous ?? 0;
+        const prevVal = previous ?? currVal;
+        return scale * currVal + (1 - scale) * (prevVal * 0.3);
+      }
+
+      function computeRecentFormMap(games) {
+        const map = new Map();
+        games.forEach((game) => {
+          const date = new Date(game.start_date);
+          const home = game.home_team;
+          const away = game.away_team;
+          const margin = (game.home_points ?? 0) - (game.away_points ?? 0);
+          if (home) {
+            if (!map.has(home)) map.set(home, []);
+            map.get(home).push({ date, margin });
+          }
+          if (away) {
+            if (!map.has(away)) map.set(away, []);
+            map.get(away).push({ date, margin: -margin });
+          }
+        });
+        map.forEach((entries) => entries.sort((a, b) => a.date - b.date));
+        return map;
+      }
+
+      function recentFormScore(team, date, formMap) {
+        const list = formMap.get(team);
+        if (!list) return 0;
+        const cutoff = new Date(date);
+        const recent = list.filter((entry) => entry.date < cutoff).slice(-5);
+        if (!recent.length) return 0;
+        const lambda = 0.7;
+        let weight = 1;
+        let totalWeight = 0;
+        let score = 0;
+        for (let i = recent.length - 1; i >= 0; i -= 1) {
+          score += recent[i].margin * weight;
+          totalWeight += weight;
+          weight *= lambda;
+        }
+        return totalWeight ? score / totalWeight : 0;
+      }
+
+      function computeAvailability(team, date) {
+        let score = 0;
+        const injuries = state.data.injuries || [];
+        injuries.forEach((entry) => {
+          if (entry.team !== team) return;
+          const status = (entry.status || '').toLowerCase();
+          if (!status.includes('out')) return;
+          const pos = normalizePosition(entry.position);
+          score -= INJURY_WEIGHTS[pos] ?? 0.2;
+        });
+        if (state.settings.manualInjuries) {
+          const overrides = state.settings.manualInjuryOverrides[team] || {};
+          TEAM_POSITIONS.forEach((pos) => {
+            if (overrides[pos]) score -= INJURY_WEIGHTS[pos] ?? 0.2;
+          });
+        }
+        return score;
+      }
+
+      function normalizePosition(pos) {
+        if (!pos) return '';
+        const normalized = pos.toUpperCase();
+        if (normalized.includes('QB')) return 'QB';
+        if (normalized.includes('WR')) return 'WR1';
+        if (normalized.includes('RB')) return 'RB1';
+        if (normalized.includes('OT') || normalized.includes('LT')) return 'LT';
+        if (normalized.includes('CB')) return 'CB1';
+        if (normalized.includes('DE') || normalized.includes('EDGE')) return 'EDGE1';
+        if (normalized.includes('S')) return 'S';
+        if (normalized.includes('K')) return 'K';
+        return normalized;
+      }
+
+      function computeWeatherAdjustments(weather) {
+        if (!weather) {
+          return { windPenalty: 0, precipPenalty: 0, confidence: 0.9 };
+        }
+        const windMph = (weather.wind ?? 0) * 0.621371;
+        const gustMph = (weather.gust ?? 0) * 0.621371;
+        const precip = weather.precipitation ?? 0;
+        const precipProb = weather.precipitation_probability ?? 0;
+        const windPenalty = -0.01 * Math.max(0, windMph - 12) - 0.002 * Math.max(0, gustMph - 18);
+        const precipPenalty = precip > 0 || precipProb > 40 ? -0.05 : 0;
+        return { windPenalty, precipPenalty, confidence: 1 };
+      }
+
+      function getMarketSpread(game) {
+        if (!state.settings.useMarkets) return { spread: null, total: null };
+        const lines = state.data.lines || [];
+        const entry = lines.find((line) => line.id === game.id || line.gameId === game.id);
+        if (!entry || !entry.lines?.length) return { spread: null, total: null };
+        const closing = entry.lines.find((item) => item.spread != null) || entry.lines[entry.lines.length - 1];
+        if (!closing) return { spread: null, total: null };
+        const spread = Number(closing.spread ?? closing.formattedSpread?.split(' ').pop());
+        const total = Number(closing.overUnder ?? closing.total);
+        let homeSpread = null;
+        if (Number.isFinite(spread)) {
+          if (closing.homeTeamSpread != null) {
+            homeSpread = Number(closing.homeTeamSpread);
+          } else if (closing.awayTeamSpread != null) {
+            homeSpread = -Number(closing.awayTeamSpread);
+          } else if (closing.formattedSpread && closing.formattedSpread.includes(game.home_team)) {
+            homeSpread = -spread;
+          } else {
+            homeSpread = spread;
+          }
+        }
+        return { spread: homeSpread, total: Number.isFinite(total) ? total : null };
+      }
+      function buildModelPayload() {
+        const upcomingGames = state.data.games || [];
+        const trainingGames = state.data.trainingGames || [];
+        const formMap = computeRecentFormMap(trainingGames);
+        const trainingRecords = [];
+        trainingGames.forEach((game) => {
+          const record = buildFeatureRecord(game, { training: true, formMap });
+          if (record) trainingRecords.push(record);
+        });
+        const upcomingRecords = [];
+        upcomingGames.forEach((game) => {
+          const record = buildFeatureRecord(game, { training: false, formMap });
+          if (record) upcomingRecords.push(record);
+        });
+        return {
+          featureNames: FEATURE_NAMES,
+          training: {
+            features: trainingRecords.map((rec) => rec.features),
+            targets: trainingRecords.map((rec) => rec.target),
+            eloDeltas: trainingRecords.map((rec) => rec.deltaR),
+            spreads: trainingRecords.map((rec) => rec.marketSpread),
+            meta: trainingRecords.map((rec) => ({
+              gameId: rec.gameId,
+              order: rec.order,
+            })),
+          },
+          upcoming: {
+            features: upcomingRecords.map((rec) => rec.features),
+            eloDeltas: upcomingRecords.map((rec) => rec.deltaR),
+            spreads: upcomingRecords.map((rec) => rec.marketSpread),
+            meta: upcomingRecords.map((rec) => ({
+              gameId: rec.gameId,
+              home: rec.home,
+              away: rec.away,
+              kickoff: rec.kickoff,
+              marketSpread: rec.marketSpread,
+              marketTotal: rec.marketTotal,
+              weatherConfidence: rec.weatherConfidence,
+            })),
+          },
+        };
+      }
+
+      function buildFeatureRecord(game, { training, formMap }) {
+        if (!game.home_team || !game.away_team) return null;
+        const season = game.season ?? determineSeasonYear(game.start_date || state.range.startDate);
+        const week = Math.max(1, (game.week ?? inferWeekFromCalendar(game.start_date, state.data.calendar)) || 1);
+        const evalWeek = Math.max(0, week - 1);
+        const homeMetrics = getTeamMetrics(game.home_team, season, evalWeek);
+        const awayMetrics = getTeamMetrics(game.away_team, season, evalWeek);
+        const homeElo = getTeamElo(game.home_team, season, evalWeek);
+        const awayElo = getTeamElo(game.away_team, season, evalWeek);
+        const homeSP = getTeamSP(game.home_team, season, evalWeek);
+        const awaySP = getTeamSP(game.away_team, season, evalWeek);
+        const deltaR = (homeElo + DEFAULT_HOME_ADV) - awayElo;
+        const offDiff = (homeMetrics.offense.ppa ?? 0) - (awayMetrics.offense.ppa ?? 0);
+        const defDiff = (awayMetrics.defense.ppa ?? 0) - (homeMetrics.defense.ppa ?? 0);
+        const tempoDelta = (homeMetrics.offense.successRate ?? 0) - (awayMetrics.offense.successRate ?? 0);
+        const neutral = Boolean(game.neutral_site);
+        const homeFlag = neutral ? 0 : 1;
+        const weather = training ? null : state.data.weather[game.id] || null;
+        const weatherAdj = computeWeatherAdjustments(weather);
+        const availability = computeAvailability(game.home_team, game.start_date) - computeAvailability(game.away_team, game.start_date);
+        const { spread, total } = getMarketSpread(game);
+        const recent = recentFormScore(game.home_team, game.start_date, formMap) - recentFormScore(game.away_team, game.start_date, formMap);
+        const spRating = (homeSP.rating ?? 0) - (awaySP.rating ?? 0);
+        const specialTeams = (homeSP.special ?? 0) - (awaySP.special ?? 0);
+        const passMismatch = ((homeMetrics.offense.passing ?? 0) - (awayMetrics.defense.passing ?? 0)) - ((awayMetrics.offense.passing ?? 0) - (homeMetrics.defense.passing ?? 0));
+        const features = [
+          deltaR / 100,
+          offDiff,
+          defDiff,
+          tempoDelta,
+          homeFlag,
+          neutral ? 1 : 0,
+          weatherAdj.windPenalty,
+          weatherAdj.precipPenalty,
+          availability,
+          spread ?? 0,
+          recent,
+          spRating / 10,
+          specialTeams / 10,
+          passMismatch,
+        ];
+        const target = training ? ((game.home_points ?? 0) > (game.away_points ?? 0) ? 1 : 0) : null;
+        return {
+          gameId: game.id,
+          home: game.home_team,
+          away: game.away_team,
+          kickoff: game.start_date,
+          features,
+          target,
+          deltaR,
+          marketSpread: spread,
+          marketTotal: total,
+          weatherConfidence: weatherAdj.confidence,
+          order: new Date(game.start_date).getTime() || Date.now(),
+        };
+      }
+      const modelWorker = createWorker();
+
+      function runPrediction() {
+        try {
+          const payload = buildModelPayload();
+          payload.calibration = state.calibration;
+          elements.predictBtn.disabled = true;
+          modelWorker.postMessage({ type: 'train-and-predict', payload });
+          showToast('Training models…', 'info');
+        } catch (err) {
+          elements.predictBtn.disabled = false;
+          console.error('Prediction failed to start', err);
+          showToast('Unable to start modeling', 'error');
+        }
+      }
+
+      function handleWorkerMessage(event) {
+        const { type, payload, error } = event.data || {};
+        if (type === 'predictions') {
+          elements.predictBtn.disabled = false;
+          state.predictions = payload.games || [];
+          if (payload.calibration) {
+            state.calibration = payload.calibration;
+            try {
+              localStorage.setItem(CALIBRATION_KEY, JSON.stringify({ ...payload.calibration, version: STATE_VERSION }));
+            } catch (err) {
+              console.error('Failed to persist calibration', err);
+            }
+          }
+          renderGames();
+          showToast('Predictions updated', 'success');
+        } else if (type === 'error') {
+          elements.predictBtn.disabled = false;
+          showToast(error || 'Modeling error', 'error');
+        }
+      }
+
+      function createWorker() {
+        const code = getWorkerCode();
+        const blob = new Blob([code], { type: 'application/javascript' });
+        const worker = new Worker(URL.createObjectURL(blob));
+        worker.onmessage = handleWorkerMessage;
+        worker.onerror = (evt) => {
+          console.error('Worker error', evt.message);
+          showToast('Worker crashed', 'error');
+        };
+        return worker;
+      }
+      function getWorkerCode() {
+        return String.raw`
+const FEATURE_LABELS = {
+  deltaR: 'Δ Elo',
+  offPpaDiff: 'Off PPA',
+  defPpaDiff: 'Def PPA',
+  tempoDelta: 'Tempo',
+  homeFlag: 'Home field',
+  neutralFlag: 'Neutral site',
+  weatherWind: 'Wind',
+  weatherPrecip: 'Precip',
+  availability: 'Availability',
+  marketSpread: 'Market spread',
+  recentForm: 'Recent form',
+  spRating: 'SP+ rating',
+  specialTeams: 'Special teams',
+  passMismatch: 'Pass mismatch'
+};
+
+function sigmoid(x) {
+  if (x > 40) return 1;
+  if (x < -40) return 0;
+  return 1 / (1 + Math.exp(-x));
+}
+
+function clip(p) {
+  return Math.min(0.999, Math.max(0.001, p));
+}
+
+function logisticPredict(weights, features) {
+  if (!weights) return 0.5;
+  let z = weights[0] || 0;
+  for (let i = 1; i < weights.length; i++) {
+    z += (weights[i] || 0) * (features[i - 1] || 0);
+  }
+  return sigmoid(z);
+}
+
+function gaussianSolve(A, b) {
+  const n = A.length;
+  const M = [];
+  for (let i = 0; i < n; i++) {
+    M[i] = A[i].slice();
+    M[i].push(b[i]);
+  }
+  for (let i = 0; i < n; i++) {
+    let maxRow = i;
+    for (let j = i + 1; j < n; j++) {
+      if (Math.abs(M[j][i]) > Math.abs(M[maxRow][i])) maxRow = j;
+    }
+    if (Math.abs(M[maxRow][i]) < 1e-9) return null;
+    if (maxRow !== i) {
+      const tmp = M[i];
+      M[i] = M[maxRow];
+      M[maxRow] = tmp;
+    }
+    const pivot = M[i][i];
+    for (let j = i; j <= n; j++) M[i][j] /= pivot;
+    for (let k = 0; k < n; k++) {
+      if (k === i) continue;
+      const factor = M[k][i];
+      for (let j = i; j <= n; j++) {
+        M[k][j] -= factor * M[i][j];
+      }
+    }
+  }
+  return M.map((row) => row[n]);
+}
+
+function logisticIRLS(X, y, lambda) {
+  const n = X.length;
+  const p = X[0] ? X[0].length : 0;
+  if (!n || !p) return { weights: [0] };
+  const beta = new Array(p + 1).fill(0);
+  const maxIter = 30;
+  const tol = 1e-5;
+  for (let iter = 0; iter < maxIter; iter++) {
+    const XtWX = Array.from({ length: p + 1 }, () => new Array(p + 1).fill(0));
+    const XtWz = new Array(p + 1).fill(0);
+    let maxChange = 0;
+    for (let i = 0; i < n; i++) {
+      const row = X[i];
+      if (!row) continue;
+      const xi = [1].concat(row);
+      let eta = 0;
+      for (let j = 0; j < beta.length; j++) {
+        eta += beta[j] * xi[j];
+      }
+      const pHat = sigmoid(eta);
+      const w = Math.max(pHat * (1 - pHat), 1e-5);
+      const z = eta + (y[i] - pHat) / w;
+      for (let a = 0; a < xi.length; a++) {
+        XtWz[a] += w * xi[a] * z;
+        for (let b = 0; b < xi.length; b++) {
+          XtWX[a][b] += w * xi[a] * xi[b];
+        }
+      }
+    }
+    for (let j = 1; j < beta.length; j++) {
+      XtWX[j][j] += lambda;
+    }
+    const next = gaussianSolve(XtWX, XtWz);
+    if (!next) break;
+    for (let j = 0; j < beta.length; j++) {
+      maxChange = Math.max(maxChange, Math.abs(beta[j] - next[j]));
+      beta[j] = next[j];
+    }
+    if (maxChange < tol) break;
+  }
+  return { weights: beta };
+}
+
+function logLoss(y, p) {
+  const clipped = clip(p);
+  return -(y ? Math.log(clipped) : Math.log(1 - clipped));
+}
+
+function createFolds(order, k) {
+  const indexed = order.map((value, idx) => ({ idx, value }));
+  indexed.sort((a, b) => a.value - b.value);
+  const n = indexed.length;
+  const folds = [];
+  const foldSize = Math.max(1, Math.floor(n / k));
+  for (let i = 0; i < k; i++) {
+    const start = i * foldSize;
+    const end = i === k - 1 ? n : start + foldSize;
+    const test = indexed.slice(start, end).map((item) => item.idx);
+    const train = indexed.slice(0, start).map((item) => item.idx);
+    if (!train.length) continue;
+    folds.push({ train, test });
+  }
+  if (!folds.length) {
+    folds.push({ train: indexed.map((item) => item.idx), test: [] });
+  }
+  return folds;
+}
+
+function crossValidateModel(X, y, order, lambdas) {
+  const n = y.length;
+  const folds = createFolds(order, Math.min(5, Math.max(2, Math.floor(n / 160) || 2)));
+  const predictions = lambdas.map(() => new Array(n).fill(null));
+  const losses = lambdas.map(() => 0);
+  const counts = lambdas.map(() => 0);
+  folds.forEach((fold) => {
+    lambdas.forEach((lambda, idx) => {
+      const trainX = fold.train.map((i) => X[i]);
+      const trainY = fold.train.map((i) => y[i]);
+      if (!trainX.length) return;
+      const model = logisticIRLS(trainX, trainY, lambda);
+      fold.test.forEach((i) => {
+        const prob = logisticPredict(model.weights, X[i]);
+        predictions[idx][i] = prob;
+        losses[idx] += logLoss(y[i], prob);
+        counts[idx] += 1;
+      });
+    });
+  });
+  let bestIdx = 0;
+  let bestLoss = Infinity;
+  lambdas.forEach((lambda, idx) => {
+    const loss = counts[idx] ? losses[idx] / counts[idx] : Infinity;
+    if (loss < bestLoss) {
+      bestLoss = loss;
+      bestIdx = idx;
+    }
+  });
+  const fallbackModel = logisticIRLS(X, y, lambdas[bestIdx]);
+  const cvPreds = predictions[bestIdx].map((p, idx) => (p != null ? p : logisticPredict(fallbackModel.weights, X[idx])));
+  const dispersion = cvPreds.reduce((acc, p) => acc + p * (1 - p), 0) / Math.max(1, cvPreds.length);
+  return { bestLambda: lambdas[bestIdx], cvPreds, dispersion, finalModel: fallbackModel };
+}
+
+function isotonicFit(scores, labels) {
+  const pairs = [];
+  for (let i = 0; i < scores.length; i++) {
+    const s = scores[i];
+    const y = labels[i];
+    if (!Number.isFinite(s)) continue;
+    pairs.push({ s, y, w: 1 });
+  }
+  if (pairs.length < 3) return null;
+  pairs.sort((a, b) => a.s - b.s);
+  const blocks = [];
+  for (let i = 0; i < pairs.length; i++) {
+    blocks.push({ w: pairs[i].w, sum: pairs[i].y * pairs[i].w, score: pairs[i].s, minScore: pairs[i].s });
+    while (blocks.length >= 2) {
+      const last = blocks[blocks.length - 1];
+      const prev = blocks[blocks.length - 2];
+      if (prev.sum / prev.w <= last.sum / last.w) break;
+      const merged = {
+        w: prev.w + last.w,
+        sum: prev.sum + last.sum,
+        score: last.score,
+        minScore: prev.minScore
+      };
+      blocks.pop();
+      blocks.pop();
+      blocks.push(merged);
+    }
+  }
+  const points = [];
+  blocks.forEach((block) => {
+    points.push({ x: block.score, y: block.sum / block.w });
+  });
+  return { type: 'isotonic', points };
+}
+
+function applyCalibrator(cal, p) {
+  if (!cal) return p;
+  if (cal.type === 'isotonic' && cal.points && cal.points.length) {
+    const pts = cal.points;
+    if (p <= pts[0].x) return pts[0].y;
+    if (p >= pts[pts.length - 1].x) return pts[pts.length - 1].y;
+    for (let i = 1; i < pts.length; i++) {
+      if (p <= pts[i].x) {
+        const x0 = pts[i - 1].x;
+        const y0 = pts[i - 1].y;
+        const x1 = pts[i].x;
+        const y1 = pts[i].y;
+        const t = (p - x0) / Math.max(1e-6, x1 - x0);
+        return y0 + t * (y1 - y0);
+      }
+    }
+  }
+  if (cal.type === 'platt') {
+    const z = (cal.a || 0) + (cal.b || 0) * p;
+    return sigmoid(z);
+  }
+  return p;
+}
+
+function plattFit(scores, labels) {
+  const X = scores.map((s) => [s]);
+  const model = logisticIRLS(X, labels, 0.01);
+  return { type: 'platt', a: model.weights[0] || 0, b: model.weights[1] || 0 };
+}
+
+function buildCalibrator(preds, labels, existing) {
+  if (!preds || preds.length < 5) return existing || null;
+  const iso = isotonicFit(preds, labels);
+  if (iso) return iso;
+  if (existing) return existing;
+  return plattFit(preds, labels);
+}
+
+function spreadModelFit(spreads, labels) {
+  const data = [];
+  for (let i = 0; i < spreads.length; i++) {
+    if (spreads[i] == null) continue;
+    data.push({ s: spreads[i], y: labels[i] });
+  }
+  if (data.length < 20) return null;
+  const X = data.map((item) => [item.s]);
+  const y = data.map((item) => item.y);
+  const model = logisticIRLS(X, y, 0.02);
+  return model.weights;
+}
+
+function spreadToProb(weights, spread) {
+  if (spread == null) return null;
+  if (!weights) {
+    return sigmoid(-0.18 * spread);
+  }
+  return sigmoid((weights[0] || 0) + (weights[1] || 0) * spread);
+}
+
+function spreadFromProb(weights, prob) {
+  const clipped = clip(prob);
+  const logit = Math.log(clipped / (1 - clipped));
+  if (!weights) {
+    const slope = -0.18;
+    return logit / slope;
+  }
+  const w1 = weights[1] || -0.18;
+  const w0 = weights[0] || 0;
+  return (logit - w0) / w1;
+}
+
+function computeBand(prob, dispersion, confidence) {
+  const clipped = clip(prob);
+  const logit = Math.log(clipped / (1 - clipped));
+  const sigma = Math.sqrt(Math.max(0.0001, dispersion)) * (2 - (confidence || 1));
+  const lower = sigmoid(logit - 1.96 * sigma);
+  const upper = sigmoid(logit + 1.96 * sigma);
+  return [clip(lower), clip(upper)];
+}
+
+function computeContributions(weights, features, names) {
+  if (!weights) return [];
+  const contributions = [];
+  for (let i = 1; i < weights.length; i++) {
+    contributions.push({ name: names[i - 1], value: (weights[i] || 0) * (features[i - 1] || 0) });
+  }
+  return contributions;
+}
+
+function summarizeDrivers(contributions) {
+  const sorted = contributions.slice().sort((a, b) => Math.abs(b.value) - Math.abs(a.value)).slice(0, 4);
+  return sorted.map((entry) => {
+    const label = FEATURE_LABELS[entry.name] || entry.name;
+    const sign = entry.value >= 0 ? '+' : '';
+    return label + ' ' + sign + entry.value.toFixed(2);
+  });
+}
+
+function buildRationale(prob, pElo, pGlm, meta) {
+  const pieces = [];
+  pieces.push('Stacked ' + Math.round(prob * 100) + '%');
+  pieces.push('Elo ' + Math.round(pElo * 100) + '%');
+  pieces.push('Form ' + Math.round(pGlm * 100) + '%');
+  if (meta && meta.marketSpread != null) {
+    pieces.push('Market ' + meta.marketSpread.toFixed(1));
+  }
+  if (meta && meta.weatherConfidence != null) {
+    pieces.push('Weather confidence ' + meta.weatherConfidence.toFixed(2));
+  }
+  return pieces.join('. ') + '.';
+}
+
+function trainAndPredict(payload) {
+  const featureNames = payload.featureNames || [];
+  const training = payload.training || {};
+  const upcoming = payload.upcoming || {};
+  const existingCal = payload.calibration || null;
+  const y = training.targets || [];
+  if (!y.length) throw new Error('Training data unavailable');
+  const order = (training.meta || []).map((m) => m.order || 0);
+  const Xglm = training.features || [];
+  const Xelo = (training.eloDeltas || []).map((d) => [d / 100]);
+  const lambdaGlm = [0.01, 0.05, 0.1, 0.2, 0.5, 1];
+  const lambdaElo = [0.001, 0.01, 0.05, 0.1];
+  const glmCV = crossValidateModel(Xglm, y, order, lambdaGlm);
+  const eloCV = crossValidateModel(Xelo, y, order, lambdaElo);
+  const glmModel = logisticIRLS(Xglm, y, glmCV.bestLambda);
+  const eloModel = logisticIRLS(Xelo, y, eloCV.bestLambda);
+  const stackFeatures = glmCV.cvPreds.map((_, i) => [eloCV.cvPreds[i], glmCV.cvPreds[i]]);
+  const stackCV = crossValidateModel(stackFeatures, y, order, [0.05]);
+  const stackModel = logisticIRLS(stackFeatures, y, 0.05);
+  const calibrator = buildCalibrator(stackCV.cvPreds, y, existingCal);
+  const spreadWeights = spreadModelFit(training.spreads || [], y);
+  const upcomingX = upcoming.features || [];
+  const upcomingElo = (upcoming.eloDeltas || []).map((d) => [d / 100]);
+  const results = [];
+  for (let i = 0; i < upcomingX.length; i++) {
+    const meta = upcoming.meta ? upcoming.meta[i] : {};
+    const pElo = logisticPredict(eloModel.weights, upcomingElo[i] || [0]);
+    const pGlm = logisticPredict(glmModel.weights, upcomingX[i]);
+    const raw = logisticPredict(stackModel.weights, [pElo, pGlm]);
+    const calibrated = applyCalibrator(calibrator, raw);
+    const confidence = Math.min(1, Math.max(0, Math.abs(calibrated - 0.5) * 2 * (meta.weatherConfidence || 1)));
+    const band = computeBand(calibrated, stackCV.dispersion || 0.1, meta.weatherConfidence || 1);
+    const spreadValue = spreadFromProb(spreadWeights, calibrated);
+    const spreadEquivValue = Number.isFinite(spreadValue) ? spreadValue : 0;
+    const marketProb = meta && meta.marketSpread != null ? spreadToProb(spreadWeights, meta.marketSpread) : null;
+    const contributions = computeContributions(glmModel.weights, upcomingX[i], featureNames);
+    const drivers = summarizeDrivers(contributions);
+    const rationale = buildRationale(calibrated, pElo, pGlm, meta);
+    results.push({
+      gameId: meta.gameId || (meta.home ? meta.home + '@' + (meta.away || '') : 'unknown'),
+      homeTeam: meta.home || 'Home',
+      awayTeam: meta.away || 'Away',
+      pHome: calibrated,
+      pAway: 1 - calibrated,
+      marginEquiv: ((calibrated - 0.5) * 24).toFixed(1),
+      spreadEquiv: spreadEquivValue.toFixed(1) + ' pts',
+      band,
+      confidence,
+      drivers,
+      rationale,
+      edge: marketProb != null ? calibrated - marketProb : null
+    });
+  }
+  return { games: results, calibration: calibrator, dispersion: stackCV.dispersion || 0.1, spreadWeights };
+}
+
+self.addEventListener('message', function(event) {
+  if (!event.data || event.data.type !== 'train-and-predict') return;
+  try {
+    const payload = event.data.payload || {};
+    const result = trainAndPredict(payload);
+    self.postMessage({ type: 'predictions', payload: result });
+  } catch (err) {
+    self.postMessage({ type: 'error', error: err && err.message ? err.message : String(err) });
+  }
+});
+`;
+      }
+      async function loadDemoData() {
+        elements.results.setAttribute('aria-busy', 'false');
+        state.data = JSON.parse(JSON.stringify(DEMO_DATA));
+        state.predictions = [];
+        populateConferenceFilter();
+        renderGames();
+        showToast('Demo dataset loaded', 'success');
+      }
+
+      function init() {
+        if (state.initialized) return;
+        state.initialized = true;
+        setupElements();
+        renderSkeleton();
+        state.range = computeWeekendRange(0);
+        updateWeekLabel();
+        setupEvents();
+        elements.marketsToggle.checked = state.settings.useMarkets;
+        elements.weatherToggle.checked = state.settings.useWeather;
+        elements.manualInjToggle.checked = state.settings.manualInjuries;
+        elements.demoToggle.checked = state.settings.demoMode;
+        elements.tzOverrideInput.value = state.settings.tzOffsetOverride ?? '';
+        if (state.settings.manualInjuries) {
+          elements.manualInjuryPanel.hidden = false;
+        }
+        if (state.settings.demoMode) {
+          loadDemoData();
+        } else {
+          refreshSlate();
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', init);
+      const DEMO_DATA = {
+        games: [
+          {
+            id: 9001,
+            season: 2024,
+            week: 5,
+            start_date: '2024-09-21T19:30:00Z',
+            home_team: 'Notre Dame',
+            away_team: 'USC',
+            home_conference: 'Ind',
+            away_conference: 'Pac-12',
+            venue: 'Notre Dame Stadium',
+            venue_id: 1,
+            neutral_site: false,
+            completed: false
+          },
+          {
+            id: 9002,
+            season: 2024,
+            week: 5,
+            start_date: '2024-09-21T23:00:00Z',
+            home_team: 'Alabama',
+            away_team: 'Georgia',
+            home_conference: 'SEC',
+            away_conference: 'SEC',
+            venue: 'Bryant-Denny Stadium',
+            venue_id: 2,
+            neutral_site: false,
+            completed: false
+          }
+        ],
+        teams: {
+          'Notre Dame': { school: 'Notre Dame', conference: 'Ind', color: '#0C2340' },
+          'USC': { school: 'USC', conference: 'Pac-12', color: '#990000' },
+          'Alabama': { school: 'Alabama', conference: 'SEC', color: '#9e1b32' },
+          'Georgia': { school: 'Georgia', conference: 'SEC', color: '#ba0c2f' }
+        },
+        venues: {
+          1: { id: 1, name: 'Notre Dame Stadium', latitude: 41.6986, longitude: -86.2353, surface: 'Grass' },
+          2: { id: 2, name: 'Bryant-Denny Stadium', latitude: 33.2083, longitude: -87.5504, surface: 'Grass' }
+        },
+        metrics: {
+          'metrics_2024_regular_4': {
+            'Notre Dame': {
+              offense: { ppa: 0.26, successRate: 0.48, explosiveness: 0.12, passing: 0.31, rushing: 0.18 },
+              defense: { ppa: -0.12, successRate: 0.37, explosiveness: 0.08, passing: -0.09, rushing: -0.1 }
+            },
+            'USC': {
+              offense: { ppa: 0.29, successRate: 0.47, explosiveness: 0.14, passing: 0.35, rushing: 0.19 },
+              defense: { ppa: 0.02, successRate: 0.42, explosiveness: 0.11, passing: 0.05, rushing: -0.02 }
+            },
+            'Alabama': {
+              offense: { ppa: 0.28, successRate: 0.49, explosiveness: 0.13, passing: 0.32, rushing: 0.2 },
+              defense: { ppa: -0.18, successRate: 0.34, explosiveness: 0.07, passing: -0.15, rushing: -0.12 }
+            },
+            'Georgia': {
+              offense: { ppa: 0.31, successRate: 0.51, explosiveness: 0.15, passing: 0.36, rushing: 0.22 },
+              defense: { ppa: -0.2, successRate: 0.32, explosiveness: 0.06, passing: -0.18, rushing: -0.14 }
+            }
+          },
+          'metrics_2023_regular_0': {
+            'Notre Dame': {
+              offense: { ppa: 0.22, successRate: 0.45, explosiveness: 0.1, passing: 0.28, rushing: 0.16 },
+              defense: { ppa: -0.1, successRate: 0.38, explosiveness: 0.09, passing: -0.08, rushing: -0.07 }
+            },
+            'USC': {
+              offense: { ppa: 0.3, successRate: 0.46, explosiveness: 0.16, passing: 0.38, rushing: 0.2 },
+              defense: { ppa: 0.05, successRate: 0.43, explosiveness: 0.12, passing: 0.1, rushing: -0.01 }
+            },
+            'Alabama': {
+              offense: { ppa: 0.27, successRate: 0.47, explosiveness: 0.12, passing: 0.31, rushing: 0.19 },
+              defense: { ppa: -0.16, successRate: 0.35, explosiveness: 0.07, passing: -0.13, rushing: -0.11 }
+            },
+            'Georgia': {
+              offense: { ppa: 0.29, successRate: 0.5, explosiveness: 0.15, passing: 0.34, rushing: 0.21 },
+              defense: { ppa: -0.19, successRate: 0.33, explosiveness: 0.06, passing: -0.16, rushing: -0.13 }
+            }
+          }
+        },
+        elo: {
+          'elo_2024_regular_4': {
+            'Notre Dame': { elo: 1705 },
+            'USC': { elo: 1660 },
+            'Alabama': { elo: 1750 },
+            'Georgia': { elo: 1785 }
+          },
+          'elo_2023_regular_0': {
+            'Notre Dame': { elo: 1670 },
+            'USC': { elo: 1680 },
+            'Alabama': { elo: 1735 },
+            'Georgia': { elo: 1770 }
+          }
+        },
+        sp: {
+          'sp_2024_regular_4': {
+            'Notre Dame': { rating: 21, offense: 35, defense: -14, special: 2 },
+            'USC': { rating: 23, offense: 37, defense: -8, special: 1 },
+            'Alabama': { rating: 25, offense: 36, defense: -12, special: 3 },
+            'Georgia': { rating: 28, offense: 38, defense: -15, special: 4 }
+          },
+          'sp_2023_regular_0': {
+            'Notre Dame': { rating: 19, offense: 33, defense: -13, special: 1 },
+            'USC': { rating: 24, offense: 38, defense: -7, special: 1 },
+            'Alabama': { rating: 24, offense: 35, defense: -11, special: 2 },
+            'Georgia': { rating: 27, offense: 37, defense: -14, special: 3 }
+          }
+        },
+        lines: [
+          { id: 9001, gameId: 9001, lines: [{ spread: -3.5, homeTeamSpread: -3.5, overUnder: 55.5 }] },
+          { id: 9002, gameId: 9002, lines: [{ spread: -2.0, homeTeamSpread: -2.0, overUnder: 49.5 }] }
+        ],
+        injuries: [
+          { team: 'USC', position: 'QB', status: 'Out', player: 'QB1', update: '2024-09-10' }
+        ],
+        weather: {
+          9001: { wind: 14, gust: 20, precipitation_probability: 20, precipitation: 0 },
+          9002: { wind: 8, gust: 15, precipitation_probability: 10, precipitation: 0 }
+        },
+        calendar: [],
+        trainingGames: [
+          { id: 7001, start_date: '2024-09-07T22:00:00Z', home_team: 'Notre Dame', away_team: 'Purdue', home_points: 31, away_points: 21, season: 2024, week: 2, completed: true },
+          { id: 7002, start_date: '2024-09-07T19:00:00Z', home_team: 'Alabama', away_team: 'Texas', home_points: 27, away_points: 24, season: 2024, week: 2, completed: true },
+          { id: 7003, start_date: '2024-08-31T23:00:00Z', home_team: 'Georgia', away_team: 'Clemson', home_points: 30, away_points: 20, season: 2024, week: 1, completed: true },
+          { id: 7004, start_date: '2023-11-25T19:00:00Z', home_team: 'USC', away_team: 'UCLA', home_points: 24, away_points: 28, season: 2023, week: 13, completed: true }
+        ]
+      };
+  </script>
+  <!-- README
+  ## CFBD API Key
+  - Sign up at https://collegefootballdata.com/key to request a free API key.
+  - Copy the issued key and paste it into the Settings panel under “Enter CFBD API key”.
+
+  ## Deploying on GitHub Pages
+  - Commit this index.html file to the root of your GitHub repository.
+  - Enable GitHub Pages in repository settings with source “main branch”.
+  - Visit the published URL (usually https://USERNAME.github.io/REPO/) to load the app.
+
+  ## Demo Mode
+  - Open Settings and toggle “Demo mode (offline sample)” to explore the interface without live APIs.
+  - Demo mode loads embedded sample data; disable it to resume live predictions.
+  -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a single-file mobile-friendly CFB winner predictor UI with settings, filters, and sticky actions
- add live data ingestion helpers for CFBD, Open-Meteo weather, lines, caching, and manual overrides with graceful fallbacks
- build web-worker modeling pipeline with IRLS logistic fits, stacking, calibration, and demo dataset for offline exploration

## Testing
- not run (static HTML/JS project)

------
https://chatgpt.com/codex/tasks/task_e_68d1b91aa0b08326a820ef17d273f2ce