### PR TITLE
Retheme layout with Vercel-inspired light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Raidline Analytics | College Football Predictions</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
-        
         * {
             margin: 0;
             padding: 0;
@@ -14,60 +12,52 @@
         }
 
         :root {
-            /* Neutral grays - inspired by Linear/Notion */
-            --gray-50: #fafafa;
-            --gray-100: #f5f5f5;
-            --gray-200: #e5e5e5;
-            --gray-300: #d4d4d4;
-            --gray-400: #a3a3a3;
-            --gray-500: #737373;
-            --gray-600: #525252;
-            --gray-700: #404040;
-            --gray-800: #262626;
-            --gray-900: #171717;
-            
-            /* Blue accent - trust & technology */
-            --blue-50: #eff6ff;
-            --blue-100: #dbeafe;
-            --blue-500: #3b82f6;
-            --blue-600: #2563eb;
-            --blue-700: #1d4ed8;
-            
-            /* Semantic colors */
-            --success: #10b981;
-            --success-light: #d1fae5;
+            --gray-50: #f9f9f9;
+            --gray-100: #f1f3f5;
+            --gray-200: #e5e7eb;
+            --gray-300: #d4d4d8;
+            --gray-400: #a1a1aa;
+            --gray-500: #71717a;
+            --gray-600: #52525b;
+            --gray-900: #111111;
+
+            --blue-500: #0070f3;
+            --blue-600: #0366d6;
+
+            --success: #0ea764;
+            --success-light: #daf5e7;
             --warning: #f59e0b;
             --warning-light: #fef3c7;
             --danger: #ef4444;
             --danger-light: #fee2e2;
-            
-            /* Application colors */
+
             --bg-primary: #ffffff;
-            --bg-secondary: var(--gray-50);
-            --bg-tertiary: var(--gray-100);
-            --text-primary: var(--gray-900);
-            --text-secondary: var(--gray-600);
-            --text-tertiary: var(--gray-400);
-            --border: var(--gray-200);
-            --border-light: var(--gray-100);
-            
-            /* Shadows - layered depth */
-            --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-            --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
-            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
-            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
-            --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
-            
-            /* Border radius */
+            --bg-secondary: #f5f5f5;
+            --bg-tertiary: #ebebeb;
+            --bg-card: #ffffff;
+            --bg-glass: #f7f8f9;
+            --text-primary: #111111;
+            --text-secondary: #333333;
+            --text-tertiary: #666666;
+            --text-muted: #888888;
+            --border: #e5e5e5;
+            --border-light: #f0f0f0;
+            --accent-primary: #0070f3;
+
+            --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.05);
+            --shadow-sm: 0 4px 6px rgba(15, 23, 42, 0.08);
+            --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.08);
+            --shadow-lg: 0 16px 40px rgba(15, 23, 42, 0.12);
+            --shadow-xl: 0 24px 60px rgba(15, 23, 42, 0.12);
+
             --radius-sm: 6px;
-            --radius-md: 8px;
-            --radius-lg: 12px;
-            --radius-xl: 16px;
-            
-            /* Transitions */
-            --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
-            --transition-base: 200ms cubic-bezier(0.4, 0, 0.2, 1);
-            --transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+            --radius-md: 10px;
+            --radius-lg: 14px;
+            --radius-xl: 20px;
+
+            --transition-fast: 150ms ease;
+            --transition-base: 200ms ease;
+            --transition-slow: 320ms ease;
         }
 
         * {
@@ -77,13 +67,12 @@
         }
 
         body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
             background: var(--bg-secondary);
             color: var(--text-primary);
-            line-height: 1.5;
+            line-height: 1.6;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
-            font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
         }
 
         .container {
@@ -94,20 +83,19 @@
 
         /* HEADER - Ultra-premium */
         header {
-            background: rgba(255, 255, 255, 0.8);
-            backdrop-filter: blur(12px) saturate(180%);
-            -webkit-backdrop-filter: blur(12px) saturate(180%);
-            border-bottom: 1px solid var(--border-light);
+            background: var(--bg-primary);
+            border-bottom: 1px solid var(--border);
             position: sticky;
             top: 0;
             z-index: 1000;
             transition: all var(--transition-base);
+            box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
         }
 
         .header-content {
             max-width: 1280px;
             margin: 0 auto;
-            padding: 16px 24px;
+            padding: 16px 20px;
             display: flex;
             align-items: center;
             justify-content: space-between;
@@ -120,13 +108,22 @@
         }
 
         h1 {
-            font-size: 20px;
+            font-size: 2rem;
             font-weight: 700;
-            background: linear-gradient(135deg, var(--blue-500) 0%, var(--blue-600) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            letter-spacing: -0.02em;
+            color: var(--text-primary);
+            letter-spacing: -0.01em;
+        }
+
+        h2 {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            letter-spacing: -0.01em;
+        }
+
+        p {
+            font-size: 1rem;
+            color: var(--text-secondary);
         }
 
         .tagline {
@@ -188,19 +185,19 @@
             border-radius: var(--radius-md);
             color: var(--text-primary);
             font-size: 15px;
-            font-family: 'Inter', sans-serif;
+            font-family: inherit;
             transition: all var(--transition-fast);
             letter-spacing: -0.01em;
         }
 
         input:hover, select:hover {
-            border-color: var(--gray-300);
+            border-color: var(--accent-primary);
         }
 
         input:focus, select:focus {
             outline: none;
-            border-color: var(--blue-500);
-            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+            border-color: var(--accent-primary);
+            box-shadow: 0 0 0 3px rgba(0, 112, 243, 0.12);
         }
 
         select {
@@ -214,34 +211,29 @@
 
         button {
             width: 100%;
-            padding: 12px;
-            background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
-            color: white;
-            border: none;
+            padding: 14px 16px;
+            background: var(--bg-primary);
+            border: 1px solid var(--accent-primary);
             border-radius: var(--radius-md);
-            font-size: 15px;
+            font-size: 1rem;
             font-weight: 600;
+            color: var(--accent-primary);
             cursor: pointer;
-            transition: all var(--transition-fast);
-            box-shadow: 0 1px 3px rgba(37, 99, 235, 0.3);
-            letter-spacing: -0.01em;
-            font-family: 'Inter', sans-serif;
+            transition: background var(--transition-fast), box-shadow var(--transition-fast), color var(--transition-fast);
+            box-shadow: var(--shadow-xs);
         }
 
         button:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
-        }
-
-        button:active {
-            transform: translateY(0);
+            background: #eef3ff;
+            box-shadow: var(--shadow-sm);
         }
 
         button:disabled {
-            background: var(--gray-300);
+            background: var(--bg-secondary);
+            border-color: var(--border);
+            color: var(--text-tertiary);
             cursor: not-allowed;
             box-shadow: none;
-            transform: none;
         }
 
         /* FILTERS - Ultra-premium */
@@ -266,59 +258,56 @@
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
             color: var(--text-secondary);
-            font-size: 13px;
+            font-size: 0.9rem;
             font-weight: 600;
             white-space: nowrap;
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
             letter-spacing: -0.01em;
         }
 
         .filter-chip:hover {
-            border-color: var(--gray-300);
             background: var(--bg-secondary);
+            color: var(--text-primary);
+            border-color: var(--border);
         }
 
         .filter-chip.active {
-            background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
-            color: white;
-            border-color: transparent;
-            box-shadow: 0 2px 8px rgba(37, 99, 235, 0.25);
+            background: var(--accent-primary);
+            color: #ffffff;
+            border-color: var(--accent-primary);
+            box-shadow: var(--shadow-xs);
         }
 
         /* SUMMARY STATS - Ultra-premium */
         .summary {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 12px;
+            grid-template-columns: 1fr;
+            gap: 16px;
             max-width: 1280px;
             margin: 0 auto;
-            padding: 0 24px 20px;
+            padding: 0 20px 24px;
         }
 
         .stat-card {
-            background: var(--bg-primary);
+            background: var(--bg-card);
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
             padding: 20px;
             text-align: center;
-            transition: all var(--transition-base);
+            transition: box-shadow var(--transition-fast), transform var(--transition-fast);
             box-shadow: var(--shadow-xs);
         }
 
         .stat-card:hover {
             transform: translateY(-2px);
-            box-shadow: var(--shadow-md);
-            border-color: var(--gray-300);
+            box-shadow: var(--shadow-sm);
         }
 
         .stat-value {
-            font-size: 36px;
-            font-weight: 800;
-            background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
+            font-size: 2.25rem;
+            font-weight: 700;
+            color: var(--accent-primary);
             letter-spacing: -0.03em;
             font-feature-settings: 'tnum';
         }
@@ -335,23 +324,22 @@
         .games-container {
             max-width: 1280px;
             margin: 0 auto;
-            padding: 32px 24px 80px;
+            padding: 24px 20px 64px;
         }
 
         .game-card {
-            background: var(--bg-primary);
+            background: var(--bg-card);
             border: 1px solid var(--border);
             border-radius: var(--radius-lg);
             overflow: hidden;
             margin-bottom: 16px;
-            transition: all var(--transition-base);
+            transition: box-shadow var(--transition-fast), transform var(--transition-fast);
             box-shadow: var(--shadow-xs);
         }
 
         .game-card:hover {
             transform: translateY(-2px);
-            box-shadow: var(--shadow-lg);
-            border-color: var(--gray-300);
+            box-shadow: var(--shadow-sm);
         }
 
         .game-header {
@@ -485,7 +473,7 @@
 
         .prob-fill {
             height: 100%;
-            background: linear-gradient(90deg, var(--blue-500), var(--blue-600));
+            background: var(--accent-primary);
             border-radius: 3px;
             transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
         }
@@ -508,7 +496,7 @@
 
         .detail-grid {
             display: grid;
-            grid-template-columns: repeat(4, 1fr);
+            grid-template-columns: repeat(2, minmax(0, 1fr));
             gap: 12px;
             margin-bottom: 16px;
         }
@@ -550,27 +538,22 @@
 
         .share-btn {
             width: 100%;
-            padding: 12px;
-            background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
-            border: none;
+            padding: 14px 16px;
+            background: var(--bg-primary);
+            border: 1px solid var(--accent-primary);
             border-radius: var(--radius-md);
-            color: white;
-            font-size: 14px;
+            color: var(--accent-primary);
+            font-size: 1rem;
             font-weight: 600;
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background var(--transition-fast), box-shadow var(--transition-fast), color var(--transition-fast);
             letter-spacing: -0.01em;
-            font-family: 'Inter', sans-serif;
-            box-shadow: 0 1px 3px rgba(37, 99, 235, 0.3);
+            box-shadow: var(--shadow-xs);
         }
 
         .share-btn:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
-        }
-
-        .share-btn:active {
-            transform: translateY(0);
+            background: #eef3ff;
+            box-shadow: var(--shadow-sm);
         }
 
         /* Badges */
@@ -708,22 +691,23 @@
 
         .share-btn {
             width: 100%;
-            padding: 12px;
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            color: var(--text-primary);
-            font-size: 14px;
-            font-weight: 700;
+            padding: 14px 16px;
+            background: var(--bg-primary);
+            border: 1px solid var(--accent-primary);
+            border-radius: var(--radius-md);
+            color: var(--accent-primary);
+            font-size: 1rem;
+            font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
+            transition: background var(--transition-fast), box-shadow var(--transition-fast), color var(--transition-fast);
+            letter-spacing: -0.01em;
+            box-shadow: var(--shadow-xs);
         }
 
         .share-btn:hover {
-            background: var(--bg-glass);
+            background: #eef3ff;
             border-color: var(--accent-primary);
+            box-shadow: var(--shadow-sm);
         }
 
         /* STATUS BAR */
@@ -789,13 +773,13 @@
         .modal {
             position: fixed;
             inset: 0;
-            background: rgba(23, 23, 23, 0.75);
-            backdrop-filter: blur(8px) saturate(120%);
-            -webkit-backdrop-filter: blur(8px) saturate(120%);
+            background: rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
             z-index: 2000;
             display: flex;
             align-items: center;
-            justify-center;
+            justify-content: center;
             padding: 20px;
             opacity: 0;
             pointer-events: none;
@@ -853,12 +837,9 @@
         }
 
         .share-title {
-            font-size: 16px;
+            font-size: 1rem;
             font-weight: 700;
-            background: linear-gradient(135deg, var(--blue-500), var(--blue-600));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
+            color: var(--accent-primary);
             letter-spacing: -0.02em;
         }
 
@@ -882,7 +863,7 @@
         /* Matchup section */
         .share-matchup {
             padding: 24px 20px;
-            background: linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+            background: var(--bg-secondary);
         }
 
         .share-teams {
@@ -995,10 +976,10 @@
         .share-prediction {
             text-align: center;
             padding: 12px;
-            background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), rgba(5, 150, 105, 0.08));
+            background: var(--success-light);
             border-radius: 8px;
             margin-bottom: 12px;
-            border: 1px solid rgba(16, 185, 129, 0.15);
+            border: 1px solid rgba(14, 167, 100, 0.2);
         }
 
         .share-prediction-label {
@@ -1118,22 +1099,23 @@
 
         .btn-close {
             flex: 1;
-            background: white;
+            background: var(--bg-primary);
             border: 1px solid var(--border);
-            box-shadow: var(--shadow-sm);
-            padding: 10px;
-            border-radius: 8px;
+            box-shadow: var(--shadow-xs);
+            padding: 12px;
+            border-radius: var(--radius-md);
             color: var(--text-primary);
-            font-size: 13px;
+            font-size: 0.95rem;
             font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s;
+            transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
             letter-spacing: -0.2px;
         }
 
         .btn-close:hover {
-            background: var(--bg-primary);
+            background: #f5f5f5;
             border-color: var(--accent-primary);
+            box-shadow: var(--shadow-sm);
         }
 
         /* VS Section - Fighting game style */
@@ -1226,16 +1208,16 @@
         .vs-badge {
             width: 44px;
             height: 44px;
-            background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+            background: var(--accent-primary);
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: 13px;
-            font-weight: 900;
-            color: white;
-            border: 3px solid #ffffff;
-            box-shadow: 0 3px 10px rgba(239, 68, 68, 0.4), 0 0 0 1px #fecaca;
+            font-weight: 700;
+            color: #ffffff;
+            border: 2px solid #ffffff;
+            box-shadow: var(--shadow-xs);
             letter-spacing: 0.5px;
         }
 
@@ -1249,10 +1231,10 @@
         .share-prediction {
             text-align: center;
             padding: 10px;
-            background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(5, 150, 105, 0.1));
+            background: var(--success-light);
             border-radius: 10px;
             margin-bottom: 10px;
-            border: 2px solid rgba(16, 185, 129, 0.2);
+            border: 1px solid rgba(14, 167, 100, 0.2);
         }
 
         .share-prediction-label {
@@ -1354,15 +1336,15 @@
         }
 
         .share-badge-upset {
-            background: linear-gradient(135deg, rgba(239, 68, 68, 0.15), rgba(220, 38, 38, 0.15));
+            background: rgba(239, 68, 68, 0.12);
             color: var(--danger);
-            border: 1.5px solid var(--danger);
+            border: 1px solid rgba(239, 68, 68, 0.3);
         }
 
         .share-badge-tossup {
-            background: linear-gradient(135deg, rgba(100, 116, 139, 0.15), rgba(71, 85, 105, 0.15));
+            background: rgba(100, 116, 139, 0.12);
             color: var(--text-secondary);
-            border: 1.5px solid var(--text-secondary);
+            border: 1px solid rgba(100, 116, 139, 0.3);
         }
 
         .modal-actions {
@@ -1373,23 +1355,23 @@
 
         .btn-close {
             flex: 1;
-            background: white;
-            border: 2px solid var(--border);
-            box-shadow: var(--shadow-sm);
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-xs);
             padding: 12px;
-            border-radius: 10px;
+            border-radius: var(--radius-md);
             color: var(--text-primary);
-            font-size: 14px;
-            font-weight: 700;
+            font-size: 0.95rem;
+            font-weight: 600;
             cursor: pointer;
-            transition: all 0.2s;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
+            transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
+            letter-spacing: 0.2px;
         }
 
         .btn-close:hover {
-            background: var(--bg-primary);
+            background: #f5f5f5;
             border-color: var(--accent-primary);
+            box-shadow: var(--shadow-sm);
         }
 
         /* EMPTY STATE */
@@ -1411,27 +1393,69 @@
         }
 
         /* RESPONSIVE */
-        @media (min-width: 768px) {
-            .games-container {
-                max-width: 800px;
-                margin: 0 auto;
+        @media (min-width: 600px) {
+            h1 {
+                font-size: 2.25rem;
             }
 
             .summary {
-                grid-template-columns: repeat(4, 1fr);
-                max-width: 800px;
-                margin: 16px auto;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                max-width: 680px;
             }
 
-            .config-panel {
-                max-width: 800px;
-                margin: 16px auto;
+            .detail-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+            }
+        }
+
+        @media (min-width: 768px) {
+            h2 {
+                font-size: 1.75rem;
             }
 
-            .filters {
-                max-width: 800px;
+            .header-content {
+                padding: 20px 32px;
+            }
+
+            .summary {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+                max-width: 960px;
+            }
+
+            .detail-grid {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+            }
+
+            .config-panel,
+            .filters,
+            .games-container {
+                max-width: 960px;
                 margin: 0 auto;
-                padding: 16px;
+            }
+
+            .games-container {
+                padding: 32px 32px 96px;
+            }
+        }
+
+        @media (min-width: 1024px) {
+            h1 {
+                font-size: 2.75rem;
+            }
+
+            .header-content {
+                padding: 24px 40px;
+            }
+
+            .summary {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                max-width: 1100px;
+            }
+
+            .config-panel,
+            .filters,
+            .games-container {
+                max-width: 1100px;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- replace the global color, typography, and spacing tokens with a Vercel-inspired light palette and system font stack
- restyle controls, cards, and share flows for minimalist light surfaces, accent borders, and mobile-first layouts
- add responsive breakpoints to scale summary stats and detail grids from single-column mobile views up to desktop widths

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddab220cb48326af9fb760b6c34ae4